### PR TITLE
Build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ env:
   - secure: CQYL7MH6tSVrCcluIfWfDSTo4E/p+9pF0eI7Vtf0oaZBzyulODHK8h/mzJp4HwezyfOu0RCedq6sloGQr1/29CvWWESaYyoGoGz9Mz2ZS+MpIcjGISfZa+x4vSp6QPFvd4i/1Z/1j2gJVVyswkrIVUwZIDJtfAKzZI5iHx2gH8Y=
   - secure: SsKJoJwtDVWrL5xxl9C/gTRy6FhfRQQNNAFOogl9mTs/WeI2t9QTYoKsxLPXOdoRdu4MvT3h/B2sjwggt7zP81fBVxQRTkg4nq0zSHlj0NqclbFa6I5lUYdGwH9gPk/HWJJwXhKRDsqn/iRw2v+qBDs/j3kIgPQ0yjM58LEPXic=
   matrix:
+  - TOXENV=lint
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy
   - TOXENV=pypy3
-  - TOXENV=lint
 sudo: false
 install:
 - travis_retry pip install tox

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ export PYLAST_API_SECRET=TODO_ENTER_YOURS_HERE
 
 To run all unit and integration tests:
 ```sh
-pip install pytest
+pip install pytest flaky
 py.test
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,26 @@
+# Release Checklist
+
+* [ ] Get master to the appropriate code release state. [Travis CI](https://travis-ci.org/pylast/pylast) should be running cleanly for all merges to master.
+* [ ] Update version in `pylast/__init__.py` and `setup.py` and commit:
+```bash
+git add pylast/__init__.py setup.py
+git commit -m "Release 1.1.0"
+```
+* [ ] Tag the last commit with the version number:
+```bash
+git tag -a 1.1.0
+```
+* [ ] Release on PyPI:
+```bash
+python setup.py register
+python setup.py sdist --format=gztar upload
+```
+* [ ] Push: `git push`
+* [ ] Push tags: `git push --tags`
+* [ ] Create new GitHub release: https://github.com/pylast/pylast/releases/new
+* [ ] Update develop branch from master:
+```bash
+git checkout develop
+git merge master --ff-only
+git push
+```

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -20,12 +20,6 @@
 #
 # http://code.google.com/p/pylast/
 
-__version__ = '1.1.0'
-__author__ = 'Amr Hassan, hugovk'
-__copyright__ = "Copyright (C) 2008-2010  Amr Hassan, 2013-2014 hugovk"
-__license__ = "apache2"
-__email__ = 'amr.hassan@gmail.com'
-
 import hashlib
 from xml.dom import minidom
 import xml.dom
@@ -36,8 +30,13 @@ import sys
 import collections
 import warnings
 import re
-
 import six
+
+__version__ = '1.1.0'
+__author__ = 'Amr Hassan, hugovk'
+__copyright__ = "Copyright (C) 2008-2010  Amr Hassan, 2013-2014 hugovk"
+__license__ = "apache2"
+__email__ = 'amr.hassan@gmail.com'
 
 
 def _deprecation_warning(message):
@@ -834,13 +833,13 @@ class LastFMNetwork(_Network):
             name="Last.fm",
             homepage="http://last.fm",
             ws_server=("ws.audioscrobbler.com", "/2.0/"),
-            api_key = api_key,
-            api_secret = api_secret,
-            session_key = session_key,
-            submission_server = "http://post.audioscrobbler.com:80/",
-            username = username,
-            password_hash = password_hash,
-            domain_names = {
+            api_key=api_key,
+            api_secret=api_secret,
+            session_key=session_key,
+            submission_server="http://post.audioscrobbler.com:80/",
+            username=username,
+            password_hash=password_hash,
+            domain_names={
                 DOMAIN_ENGLISH: 'www.last.fm',
                 DOMAIN_GERMAN: 'www.lastfm.de',
                 DOMAIN_SPANISH: 'www.lastfm.es',
@@ -854,7 +853,7 @@ class LastFMNetwork(_Network):
                 DOMAIN_JAPANESE: 'www.lastfm.jp',
                 DOMAIN_CHINESE: 'cn.last.fm',
             },
-            urls = {
+            urls={
                 "album": "music/%(artist)s/%(album)s",
                 "artist": "music/%(artist)s",
                 "event": "event/%(id)s",
@@ -930,13 +929,13 @@ class LibreFMNetwork(_Network):
             name="Libre.fm",
             homepage="http://alpha.libre.fm",
             ws_server=("alpha.libre.fm", "/2.0/"),
-            api_key = api_key,
-            api_secret = api_secret,
-            session_key = session_key,
-            submission_server = "http://turtle.libre.fm:80/",
-            username = username,
-            password_hash = password_hash,
-            domain_names = {
+            api_key=api_key,
+            api_secret=api_secret,
+            session_key=session_key,
+            submission_server="http://turtle.libre.fm:80/",
+            username=username,
+            password_hash=password_hash,
+            domain_names={
                 DOMAIN_ENGLISH: "alpha.libre.fm",
                 DOMAIN_GERMAN: "alpha.libre.fm",
                 DOMAIN_SPANISH: "alpha.libre.fm",
@@ -950,7 +949,7 @@ class LibreFMNetwork(_Network):
                 DOMAIN_JAPANESE: "alpha.libre.fm",
                 DOMAIN_CHINESE: "alpha.libre.fm",
             },
-            urls = {
+            urls={
                 "album": "artist/%(artist)s/album/%(album)s",
                 "artist": "artist/%(artist)s",
                 "event": "event/%(id)s",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import os
-
 from setuptools import setup, find_packages
 
 

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -2,6 +2,7 @@
 """
 Integration (not unit) tests for pylast.py
 """
+from flaky import flaky
 import os
 import pytest
 from random import choice
@@ -30,6 +31,7 @@ def load_secrets():
     return doc
 
 
+@flaky
 class TestPyLast(unittest.TestCase):
 
     secrets = None

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
      mock
      ipdb
      pytest-cov
+     flaky
 commands = py.test -v --cov pylast --cov-report term-missing {posargs}
 
 [testenv:venv]


### PR DESCRIPTION
Build things:

 * Integration tests currently run against the real Last.fm network and occasionally fail due to network errors. Ideally this could be mocked to run offline (see https://github.com/pylast/pylast/issues/105) but for now, use flaky to rerun failing integration tests. This may need fine-tuning.

 * pep8 (version 1.6.2) is now more strict and fails the lint test due to things like spaces around operators.  (Version 1.5.7 didn't fail.) Fix these. 

 * Run lint tests first. They only take about 30 seconds compared to 8-10 minutes for the full tests.

 * Remove an unused import.

Also:

 * Add a release checklist.