### PR TITLE
Remove artist.getImages and deprecation note

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -192,19 +192,6 @@ class _Network(object):
             self.session_key = sk_gen.get_session_key(
                 self.username, self.password_hash)
 
-    """def __repr__(self):
-        attributes = ("name", "homepage", "ws_server", "api_key", "api_secret",
-            "session_key", "submission_server", "username", "password_hash",
-            "domain_names", "urls")
-
-        text = "pylast._Network(%s)"
-        args = []
-        for attr in attributes:
-            args.append("=".join((attr, repr(getattr(self, attr)))))
-
-        return text % ", ".join(args)
-    """
-
     def __str__(self):
         return "%s Network" % self.name
 

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2077,14 +2077,6 @@ class Artist(_BaseObject, _Taggable):
         return self.network._get_url(
             domain_name, "artist") % {'artist': artist}
 
-    def get_images(self, order=IMAGES_ORDER_POPULARITY, limit=None):
-        """
-        The artist.getImages method has been deprecated by Last.fm.
-        """
-        raise WSError(
-            self.network, "27",
-            "The artist.getImages method has been deprecated by Last.fm.")
-
     def shout(self, message):
         """
             Post a shout

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -36,11 +36,6 @@ class TestPyLast(unittest.TestCase):
 
     secrets = None
 
-    # To remove Python 3's
-    # "DeprecationWarning: Please use assertRaisesRegex instead"
-    if sys.version_info[0] == 2:
-        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
-
     def unix_timestamp(self):
         return int(time.time())
 
@@ -761,14 +756,6 @@ class TestPyLast(unittest.TestCase):
 
         # Assert
         self.assertEqual(name, "Last.fm Network")
-
-    def test_artist_get_images_deprecated(self):
-        # Arrange
-        artist = self.network.get_artist("Test Artist")
-
-        # Act/Assert
-        with self.assertRaisesRegex(pylast.WSError, 'deprecated'):
-            artist.get_images()
 
     def helper_validate_results(self, a, b, c):
         # Assert

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -6,7 +6,6 @@ from flaky import flaky
 import os
 import pytest
 from random import choice
-import sys
 import time
 import unittest
 


### PR DESCRIPTION
Last.fm began serving a deprecation notice for artist.getImages in 2013 after having delisted it for over a year.

www.last.fm/group/Last.fm+Web+Services/forum/21604/_/2216689
http://wayback.archive.org/web/20120114035312/http://www.last.fm/api/show/artist.getImages

Calling the API now results in:
```xml
<lfm status="failed">
<error code="27">The artist.getImages method has been deprecated.</error>
</lfm>
```

pylast has been returning a deprecation exception since https://github.com/pylast/pylast/commit/d3dba1475ab1615aae421d1e418f9134554c561c#diff-fcdfb9e45a4cd992ea6f74b1eea6123cR2024 (Mar 7, 2014), released in pylast 1.0.0 (Jul 29, 2014):

```python
    def get_images(self, order=IMAGES_ORDER_POPULARITY, limit=None):
        """
        The artist.getImages method has been deprecated by Last.fm.
        """
        raise WSError(
            self.network, "27",
            "The artist.getImages method has been deprecated by Last.fm.")
```

Let's just remove the method entirely now.
