### PR TITLE
Support for artist.getCorrection and track.getCorrection

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1928,6 +1928,12 @@ class Artist(_BaseObject, _Taggable):
 
         return self.name
 
+    def get_correction(self):
+        """Returns the corrected artist name."""
+        
+        return _extract(
+            self._request(self.ws_prefix + ".getCorrection"), "name")
+
     def get_cover_image(self, size=COVER_MEGA):
         """
         Returns a uri to the cover image

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1930,7 +1930,7 @@ class Artist(_BaseObject, _Taggable):
 
     def get_correction(self):
         """Returns the corrected artist name."""
-        
+
         return _extract(
             self._request(self.ws_prefix + ".getCorrection"), "name")
 
@@ -2952,12 +2952,12 @@ class Track(_Opus):
 
     def __init__(self, artist, title, network, username=None):
         super(Track, self).__init__(artist, title, network, "track", username)
-        
+
     def get_correction(self):
         """Returns the corrected track name."""
-        
+
         return _extract(
-            self._request(self.ws_prefix + ".getCorrection"), "name") 
+            self._request(self.ws_prefix + ".getCorrection"), "name")
 
     def get_duration(self):
         """Returns the track duration."""

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2952,6 +2952,12 @@ class Track(_Opus):
 
     def __init__(self, artist, title, network, username=None):
         super(Track, self).__init__(artist, title, network, "track", username)
+        
+    def get_correction(self):
+        """Returns the corrected track name."""
+        
+        return _extract(
+            self._request(self.ws_prefix + ".getCorrection"), "name") 
 
     def get_duration(self):
         """Returns the track duration."""

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -1907,7 +1907,16 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(len(tracks), 1)
         self.assertEqual(str(tracks[0].track.artist), "Johnny Cash")
         self.assertEqual(str(tracks[0].track.title), "Ring of Fire")
-
+        
+    def test_artist_get_correction(self):
+        # Arrange
+        artist = pylast.Artist("guns and roses", self.network)
+        
+        # Act
+        corrected_artist_name = artist.get_correction()
+        
+        # Assert
+        self.assertEqual(corrected_artist_name, "Guns N' Roses")
 
 if __name__ == '__main__':
     unittest.main(failfast=True)

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -1907,24 +1907,24 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(len(tracks), 1)
         self.assertEqual(str(tracks[0].track.artist), "Johnny Cash")
         self.assertEqual(str(tracks[0].track.title), "Ring of Fire")
-        
+
     def test_artist_get_correction(self):
         # Arrange
         artist = pylast.Artist("guns and roses", self.network)
-        
+
         # Act
         corrected_artist_name = artist.get_correction()
-        
+
         # Assert
         self.assertEqual(corrected_artist_name, "Guns N' Roses")
-        
+
     def test_track_get_correction(self):
         # Arrange
         track = pylast.Track("Guns N' Roses", "mrbrownstone", self.network)
-        
+
         # Act
         corrected_track_name = track.get_correction()
-        
+
         # Assert
         self.assertEqual(corrected_track_name, "Mr. Brownstone")
 

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -1917,6 +1917,16 @@ class TestPyLast(unittest.TestCase):
         
         # Assert
         self.assertEqual(corrected_artist_name, "Guns N' Roses")
+        
+    def test_track_get_correction(self):
+        # Arrange
+        track = pylast.Track("Guns N' Roses", "mrbrownstone", self.network)
+        
+        # Act
+        corrected_track_name = track.get_correction()
+        
+        # Assert
+        self.assertEqual(corrected_track_name, "Mr. Brownstone")
 
 if __name__ == '__main__':
     unittest.main(failfast=True)


### PR DESCRIPTION
Added support for [artist.getCorrection](http://www.lastfm.com.br/api/show/artist.getCorrection) and [track.getCorrection](http://www.lastfm.com.br/api/show/track.getCorrection).

Don't know, maybe I overlooked the Track.get_correction() . The request has two 'name' elements, I'm picking the first one, right? 

And what about try to correct by default?