### PR TITLE
Fix get_recent_tracks (and more)

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -4030,7 +4030,7 @@ def _collect_nodes(limit, sender, method_name, cacheable, params=None):
         params["page"] = str(page)
         doc = sender._request(method_name, cacheable, params)
 
-        main = doc.documentElement.childNodes[1]
+        main = doc.documentElement.childNodes[0]
 
         if main.hasAttribute("totalPages"):
             total_pages = _number(main.getAttribute("totalPages"))


### PR DESCRIPTION
Fixes https://github.com/pylast/pylast/issues/141.

`_collect_nodes()` contains the line:
```python
        main = doc.documentElement.childNodes[1]
```

However, `doc.documentElement.childNodes` looks like this:
```
[<DOM Element: recenttracks at 0x10ba9e9e0>, <DOM Text node "u'\n'">]
```

Whatever used to be in index [1] is clearly not what we want now. Changing that `[1]` to `[0]` fixes it.

Without the fix:
> 71 failed, 85 passed 
https://travis-ci.org/pylast/pylast/builds/78444843

With the fix:
>  63 failed, 93 passed
https://travis-ci.org/hugovk/pylast/jobs/78438621