### PR TITLE
Fix get_recent_tracks (and more)

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -21,7 +21,7 @@
 # https://github.com/pylast/pylast
 
 import hashlib
-from xml.dom import minidom
+from xml.dom import minidom, Node
 import xml.dom
 import time
 import shelve
@@ -4014,6 +4014,16 @@ def _string(string):
     return casted
 
 
+def cleanup_nodes(doc):
+    """
+    Remove text nodes containing only whitespace
+    """
+    for node in doc.documentElement.childNodes:
+        if node.nodeType == Node.TEXT_NODE and node.nodeValue.isspace():
+            doc.documentElement.removeChild(node)
+    return doc
+
+
 def _collect_nodes(limit, sender, method_name, cacheable, params=None):
     """
     Returns a sequence of dom.Node objects about as close to limit as possible
@@ -4029,8 +4039,9 @@ def _collect_nodes(limit, sender, method_name, cacheable, params=None):
     while not end_of_pages and (not limit or (limit and len(nodes) < limit)):
         params["page"] = str(page)
         doc = sender._request(method_name, cacheable, params)
+        doc = cleanup_nodes(doc)
 
-        main = doc.documentElement.childNodes[1]
+        main = doc.documentElement.childNodes[0]
 
         if main.hasAttribute("totalPages"):
             total_pages = _number(main.getAttribute("totalPages"))


### PR DESCRIPTION
Fixes https://github.com/pylast/pylast/issues/141 without breaking Libre.fm support.

Replaces PR #144.

---

`_collect_nodes()` contains the line:
```python
        main = doc.documentElement.childNodes[1]
```

However, `doc.documentElement.childNodes` looks like this:
```
[<DOM Element: recenttracks at 0x10ba9e9e0>, <DOM Text node "u'\n'">]
```

Whatever used to be in index [1] is clearly not what we want now. Changing that `[1]` to `[0]` fixes it.

---

Without the fix:
> 71 failed, 85 passed 

https://travis-ci.org/pylast/pylast/builds/78444843

With the fix:
>  63 failed, 93 passed

https://travis-ci.org/hugovk/pylast/jobs/78570768