### PR TITLE
x.next() -> next(x) for python3 compat

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1814,8 +1814,8 @@ class _Opus(_BaseObject, _Taggable):
 
         try:
             lfm = doc.getElementsByTagName('lfm')[0]
-            opus = self._get_children_by_tag_name(lfm, self.ws_prefix).next()
-            mbid = self._get_children_by_tag_name(opus, "mbid").next()
+            opus = next(self._get_children_by_tag_name(lfm, self.ws_prefix))
+            mbid = next(self._get_children_by_tag_name(opus, "mbid"))
             return mbid.firstChild.nodeValue
         except StopIteration:
             return None


### PR DESCRIPTION
`.next()` is renamed `.__next__` in py3k, use `next()`