### PR TITLE
Skip tests caused by the broken Last.fm API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
 # C extensions
 *.so
@@ -8,11 +9,12 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
-bin/
 build/
 develop-eggs/
 dist/
+downloads/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/
@@ -22,6 +24,12 @@ var/
 .installed.cfg
 *.egg
 
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -30,33 +38,22 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
-output.html
-output.xml
+*,cover
+.hypothesis/
 
 # Translations
 *.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
+*.pot
 
 # Django stuff:
 *.log
-*.pot
 
 # Sphinx documentation
 docs/_build/
 
-# Test files
-test_pylast.yaml
-lastfm.txt.pkl
-secrets.sh
-
-.dir-locals.el
+# PyBuilder
+target/

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -31,6 +31,7 @@ def load_secrets():
 
 
 def handle_lastfm_exceptions(f):
+    """Skip exceptions caused by Last.fm's broken API"""
     def wrapper(*args, **kw):
         try:
             return f(*args, **kw)
@@ -67,6 +68,7 @@ class TestPyLast(unittest.TestCase):
             api_key=API_KEY, api_secret=API_SECRET,
             username=self.username, password_hash=password_hash)
 
+    @handle_lastfm_exceptions
     def test_scrobble(self):
         # Arrange
         artist = "Test Artist"
@@ -84,6 +86,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(str(last_scrobble.track.title),  str(title))
         self.assertEqual(str(last_scrobble.timestamp),    str(timestamp))
 
+    @handle_lastfm_exceptions
     def test_unscrobble(self):
         # Arrange
         artist = "Test Artist 2"
@@ -119,6 +122,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertTrue(value)
 
+    @handle_lastfm_exceptions
     def test_remove_album(self):
         # Arrange
         library = pylast.Library(user=self.username, network=self.network)
@@ -140,6 +144,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertFalse(value)
 
+    @handle_lastfm_exceptions
     def test_add_artist(self):
         # Arrange
         artist = "Test Artist 2"
@@ -156,6 +161,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertTrue(value)
 
+    @handle_lastfm_exceptions
     def test_remove_artist(self):
         # Arrange
         # Get plenty of artists
@@ -176,6 +182,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertFalse(value)
 
+    @handle_lastfm_exceptions
     def test_get_venue(self):
         # Arrange
         venue_name = "Last.fm Office"
@@ -188,6 +195,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertEqual(str(venue.id), "8778225")
 
+    @handle_lastfm_exceptions
     def test_get_user_registration(self):
         # Arrange
         username = "RJ"
@@ -200,6 +208,7 @@ class TestPyLast(unittest.TestCase):
         # Just check date because of timezones
         self.assertIn(u"2002-11-20 ", registered)
 
+    @handle_lastfm_exceptions
     def test_get_user_unixtime_registration(self):
         # Arrange
         username = "RJ"
@@ -212,6 +221,7 @@ class TestPyLast(unittest.TestCase):
         # Just check date because of timezones
         self.assertEqual(unixtime_registered, u"1037793040")
 
+    @handle_lastfm_exceptions
     def test_get_genderless_user(self):
         # Arrange
         # Currently test_user has no gender set:
@@ -223,6 +233,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertIsNone(gender)
 
+    @handle_lastfm_exceptions
     def test_get_countryless_user(self):
         # Arrange
         # Currently test_user has no country set:
@@ -234,6 +245,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertIsNone(country)
 
+    @handle_lastfm_exceptions
     def test_love(self):
         # Arrange
         artist = "Test Artist"
@@ -249,6 +261,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(str(loved[0].track.artist), "Test Artist")
         self.assertEqual(str(loved[0].track.title), "Test Title")
 
+    @handle_lastfm_exceptions
     def test_unlove(self):
         # Arrange
         artist = pylast.Artist("Test Artist", self.network)
@@ -266,6 +279,7 @@ class TestPyLast(unittest.TestCase):
             self.assertNotEqual(str(loved.track.artist), "Test Artist")
             self.assertNotEqual(str(loved.track.title), "Test Title")
 
+    @handle_lastfm_exceptions
     def test_get_100_albums(self):
         # Arrange
         library = pylast.Library(user=self.username, network=self.network)
@@ -276,6 +290,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertGreaterEqual(len(albums), 0)
 
+    @handle_lastfm_exceptions
     def test_get_limitless_albums(self):
         # Arrange
         library = pylast.Library(user=self.username, network=self.network)
@@ -286,6 +301,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertGreaterEqual(len(albums), 0)
 
+    @handle_lastfm_exceptions
     def test_user_equals_none(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -296,6 +312,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertFalse(value)
 
+    @handle_lastfm_exceptions
     def test_user_not_equal_to_none(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -306,6 +323,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertTrue(value)
 
+    @handle_lastfm_exceptions
     def test_now_playing_user_with_no_scrobbles(self):
         # Arrange
         # Currently test-account has no scrobbles:
@@ -317,6 +335,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertIsNone(current_track)
 
+    @handle_lastfm_exceptions
     def test_love_limits(self):
         # Arrange
         # Currently test-account has at least 23 loved tracks:
@@ -328,6 +347,7 @@ class TestPyLast(unittest.TestCase):
         self.assertGreaterEqual(len(user.get_loved_tracks(limit=None)), 23)
         self.assertGreaterEqual(len(user.get_loved_tracks(limit=0)), 23)
 
+    @handle_lastfm_exceptions
     def test_update_now_playing(self):
         # Arrange
         artist = "Test Artist"
@@ -346,6 +366,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(str(current_track.title), "Test Title")
         self.assertEqual(str(current_track.artist), "Test Artist")
 
+    @handle_lastfm_exceptions
     def test_libre_fm(self):
         # Arrange
         username = self.__class__.secrets["username"]
@@ -360,6 +381,7 @@ class TestPyLast(unittest.TestCase):
         self.assertGreater(len(tags), 0)
         self.assertIsInstance(tags[0], pylast.TopItem)
 
+    @handle_lastfm_exceptions
     def test_album_tags_are_topitems(self):
         # Arrange
         albums = self.network.get_user('RJ').get_top_albums()
@@ -382,6 +404,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(thing)
         self.assertEqual(len(things), 1)
 
+    @handle_lastfm_exceptions
     def test_album_is_hashable(self):
         # Arrange
         album = self.network.get_album("Test Artist", "Test Album")
@@ -389,6 +412,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(album)
 
+    @handle_lastfm_exceptions
     def test_artist_is_hashable(self):
         # Arrange
         test_artist = self.network.get_artist("Test Artist")
@@ -398,6 +422,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(artist)
 
+    @handle_lastfm_exceptions
     def test_country_is_hashable(self):
         # Arrange
         country = self.network.get_country("Italy")
@@ -405,6 +430,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(country)
 
+    @handle_lastfm_exceptions
     def test_metro_is_hashable(self):
         # Arrange
         metro = self.network.get_metro("Helsinki", "Finland")
@@ -412,6 +438,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(metro)
 
+    @handle_lastfm_exceptions
     def test_event_is_hashable(self):
         # Arrange
         user = self.network.get_user("RJ")
@@ -420,6 +447,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(event)
 
+    @handle_lastfm_exceptions
     def test_group_is_hashable(self):
         # Arrange
         group = self.network.get_group("Audioscrobbler Beta")
@@ -427,6 +455,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(group)
 
+    @handle_lastfm_exceptions
     def test_library_is_hashable(self):
         # Arrange
         library = pylast.Library(user=self.username, network=self.network)
@@ -434,6 +463,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(library)
 
+    @handle_lastfm_exceptions
     def test_playlist_is_hashable(self):
         # Arrange
         playlist = pylast.Playlist(
@@ -442,6 +472,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(playlist)
 
+    @handle_lastfm_exceptions
     def test_tag_is_hashable(self):
         # Arrange
         tag = self.network.get_top_tags(limit=1)[0]
@@ -449,6 +480,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(tag)
 
+    @handle_lastfm_exceptions
     def test_track_is_hashable(self):
         # Arrange
         artist = self.network.get_artist("Test Artist")
@@ -458,6 +490,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(track)
 
+    @handle_lastfm_exceptions
     def test_user_is_hashable(self):
         # Arrange
         artist = self.network.get_artist("Test Artist")
@@ -467,6 +500,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(user)
 
+    @handle_lastfm_exceptions
     def test_venue_is_hashable(self):
         # Arrange
         venue_id = "8778225"  # Last.fm office
@@ -475,6 +509,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(venue)
 
+    @handle_lastfm_exceptions
     def test_xspf_is_hashable(self):
         # Arrange
         xspf = pylast.XSPF(
@@ -483,6 +518,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_is_thing_hashable(xspf)
 
+    @handle_lastfm_exceptions
     def test_invalid_xml(self):
         # Arrange
         # Currently causes PCDATA invalid Char value 25
@@ -496,6 +532,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertGreaterEqual(int(total), 0)
 
+    @handle_lastfm_exceptions
     def test_user_play_count_in_track_info(self):
         # Arrange
         artist = "Test Artist"
@@ -510,6 +547,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertGreaterEqual(count, 0)
 
+    @handle_lastfm_exceptions
     def test_user_loved_in_track_info(self):
         # Arrange
         artist = "Test Artist"
@@ -526,6 +564,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(loved, bool)
         self.assertNotIsInstance(loved, str)
 
+    @handle_lastfm_exceptions
     def test_album_in_recent_tracks(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -537,6 +576,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertTrue(hasattr(track, 'album'))
 
+    @handle_lastfm_exceptions
     def test_album_in_artist_tracks(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -547,6 +587,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertTrue(hasattr(track, 'album'))
 
+    @handle_lastfm_exceptions
     def test_enable_rate_limiting(self):
         # Arrange
         self.assertFalse(self.network.is_rate_limited())
@@ -564,6 +605,7 @@ class TestPyLast(unittest.TestCase):
         self.assertTrue(self.network.is_rate_limited())
         self.assertGreaterEqual(now - then, 0.2)
 
+    @handle_lastfm_exceptions
     def test_disable_rate_limiting(self):
         # Arrange
         self.network.enable_rate_limit()
@@ -614,6 +656,7 @@ class TestPyLast(unittest.TestCase):
         for event in events[:2]:  # checking first two should be enough
             self.assertIsInstance(event.get_headliner(), pylast.Artist)
 
+    @handle_lastfm_exceptions
     def test_artist_upcoming_events_returns_valid_ids(self):
         # Arrange
         artist = pylast.Artist("Test Artist", self.network)
@@ -621,6 +664,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_upcoming_events_have_valid_ids(artist)
 
+    @handle_lastfm_exceptions
     def test_user_past_events_returns_valid_ids(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -628,6 +672,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_past_events_have_valid_ids(lastfm_user)
 
+    @handle_lastfm_exceptions
     def test_user_recommended_events_returns_valid_ids(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -638,6 +683,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_assert_events_have_valid_ids(events)
 
+    @handle_lastfm_exceptions
     def test_user_upcoming_events_returns_valid_ids(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -645,6 +691,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_upcoming_events_have_valid_ids(lastfm_user)
 
+    @handle_lastfm_exceptions
     def test_venue_past_events_returns_valid_ids(self):
         # Arrange
         venue_id = "8778225"  # Last.fm office
@@ -653,6 +700,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_past_events_have_valid_ids(venue)
 
+    @handle_lastfm_exceptions
     def test_venue_upcoming_events_returns_valid_ids(self):
         # Arrange
         venue_id = "8778225"  # Last.fm office
@@ -661,6 +709,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_upcoming_events_have_valid_ids(venue)
 
+    @handle_lastfm_exceptions
     def test_pickle(self):
         # Arrange
         import pickle
@@ -677,6 +726,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertEqual(lastfm_user, loaded_user)
 
+    @handle_lastfm_exceptions
     def test_bio_published_date(self):
         # Arrange
         artist = pylast.Artist("Test Artist", self.network)
@@ -688,6 +738,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(bio)
         self.assertGreaterEqual(len(bio), 1)
 
+    @handle_lastfm_exceptions
     def test_bio_content(self):
         # Arrange
         artist = pylast.Artist("Test Artist", self.network)
@@ -699,6 +750,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(bio)
         self.assertGreaterEqual(len(bio), 1)
 
+    @handle_lastfm_exceptions
     def test_bio_summary(self):
         # Arrange
         artist = pylast.Artist("Test Artist", self.network)
@@ -710,6 +762,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(bio)
         self.assertGreaterEqual(len(bio), 1)
 
+    @handle_lastfm_exceptions
     def test_album_wiki_content(self):
         # Arrange
         album = pylast.Album("Test Artist", "Test Album", self.network)
@@ -721,6 +774,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(wiki)
         self.assertGreaterEqual(len(wiki), 1)
 
+    @handle_lastfm_exceptions
     def test_album_wiki_published_date(self):
         # Arrange
         album = pylast.Album("Test Artist", "Test Album", self.network)
@@ -732,6 +786,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(wiki)
         self.assertGreaterEqual(len(wiki), 1)
 
+    @handle_lastfm_exceptions
     def test_album_wiki_summary(self):
         # Arrange
         album = pylast.Album("Test Artist", "Test Album", self.network)
@@ -743,6 +798,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(wiki)
         self.assertGreaterEqual(len(wiki), 1)
 
+    @handle_lastfm_exceptions
     def test_track_wiki_content(self):
         # Arrange
         track = pylast.Track("Test Artist", "Test Title", self.network)
@@ -754,6 +810,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(wiki)
         self.assertGreaterEqual(len(wiki), 1)
 
+    @handle_lastfm_exceptions
     def test_track_wiki_summary(self):
         # Arrange
         track = pylast.Track("Test Artist", "Test Title", self.network)
@@ -765,6 +822,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsNotNone(wiki)
         self.assertGreaterEqual(len(wiki), 1)
 
+    @handle_lastfm_exceptions
     def test_lastfm_network_name(self):
         # Act
         name = str(self.network)
@@ -796,6 +854,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_validate_results(result1, result2, result3)
 
+    @handle_lastfm_exceptions
     def test_cacheable_artist_get_shouts(self):
         # Arrange
         artist = self.network.get_artist("Test Artist")
@@ -803,6 +862,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_validate_cacheable(artist, "get_shouts")
 
+    @handle_lastfm_exceptions
     def test_cacheable_event_get_shouts(self):
         # Arrange
         user = self.network.get_user("RJ")
@@ -811,6 +871,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_validate_cacheable(event, "get_shouts")
 
+    @handle_lastfm_exceptions
     def test_cacheable_track_get_shouts(self):
         # Arrange
         track = self.network.get_top_tracks()[0].item
@@ -818,6 +879,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_validate_cacheable(track, "get_shouts")
 
+    @handle_lastfm_exceptions
     def test_cacheable_group_get_members(self):
         # Arrange
         group = self.network.get_group("Audioscrobbler Beta")
@@ -825,6 +887,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_validate_cacheable(group, "get_members")
 
+    @handle_lastfm_exceptions
     def test_cacheable_library(self):
         # Arrange
         library = pylast.Library(self.username, self.network)
@@ -834,6 +897,7 @@ class TestPyLast(unittest.TestCase):
         self.helper_validate_cacheable(library, "get_artists")
         self.helper_validate_cacheable(library, "get_tracks")
 
+    @handle_lastfm_exceptions
     def test_cacheable_user_artist_tracks(self):
         # Arrange
         lastfm_user = self.network.get_authenticated_user()
@@ -846,6 +910,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_validate_results(result1, result2, result3)
 
+    @handle_lastfm_exceptions
     def test_cacheable_user(self):
         # Arrange
         lastfm_user = self.network.get_authenticated_user()
@@ -860,6 +925,7 @@ class TestPyLast(unittest.TestCase):
         self.helper_validate_cacheable(lastfm_user, "get_recommended_events")
         self.helper_validate_cacheable(lastfm_user, "get_shouts")
 
+    @handle_lastfm_exceptions
     def test_geo_get_events_in_location(self):
         # Arrange
         # Act
@@ -873,6 +939,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIn(event.get_venue().location['city'],
                       ["London", "Camden"])
 
+    @handle_lastfm_exceptions
     def test_geo_get_events_in_latlong(self):
         # Arrange
         # Act
@@ -885,6 +952,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(event, pylast.Event)
         self.assertEqual(event.get_venue().location['city'], "Manchester")
 
+    @handle_lastfm_exceptions
     def test_geo_get_events_festival(self):
         # Arrange
         # Act
@@ -904,6 +972,7 @@ class TestPyLast(unittest.TestCase):
         (start, end) = dates[0]
         self.assertLess(start, end)
 
+    @handle_lastfm_exceptions
     def test_get_metro_weekly_chart_dates(self):
         # Arrange
         # Act
@@ -929,32 +998,39 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(chart[0], pylast.TopItem)
         self.assertIsInstance(chart[0].item, expected_type)
 
+    @handle_lastfm_exceptions
     def test_get_metro_artist_chart(self):
         # Arrange/Act/Assert
         self.helper_geo_chart("get_artist_chart")
 
+    @handle_lastfm_exceptions
     def test_get_metro_hype_artist_chart(self):
         # Arrange/Act/Assert
         self.helper_geo_chart("get_hype_artist_chart")
 
+    @handle_lastfm_exceptions
     def test_get_metro_unique_artist_chart(self):
         # Arrange/Act/Assert
         self.helper_geo_chart("get_unique_artist_chart")
 
+    @handle_lastfm_exceptions
     def test_get_metro_track_chart(self):
         # Arrange/Act/Assert
         self.helper_geo_chart("get_track_chart", expected_type=pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_get_metro_hype_track_chart(self):
         # Arrange/Act/Assert
         self.helper_geo_chart(
             "get_hype_track_chart", expected_type=pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_get_metro_unique_track_chart(self):
         # Arrange/Act/Assert
         self.helper_geo_chart(
             "get_unique_track_chart", expected_type=pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_geo_get_metros(self):
         # Arrange
         # Act
@@ -965,6 +1041,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(metros[0], pylast.Metro)
         self.assertEqual(metros[0].get_country(), "Poland")
 
+    @handle_lastfm_exceptions
     def test_geo_get_top_artists(self):
         # Arrange
         # Act
@@ -976,6 +1053,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(artists[0], pylast.TopItem)
         self.assertIsInstance(artists[0].item, pylast.Artist)
 
+    @handle_lastfm_exceptions
     def test_geo_get_top_tracks(self):
         # Arrange
         # Act
@@ -987,6 +1065,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(tracks[0], pylast.TopItem)
         self.assertIsInstance(tracks[0].item, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_metro_class(self):
         # Arrange
         # Act
@@ -1001,6 +1080,7 @@ class TestPyLast(unittest.TestCase):
             metro,
             pylast.Metro("Wellington", "New Zealand", self.network))
 
+    @handle_lastfm_exceptions
     def test_get_album_play_links(self):
         # Arrange
         album1 = self.network.get_album("Portishead", "Dummy")
@@ -1016,6 +1096,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIn("spotify:album:", links[0])
         self.assertIn("spotify:album:", links[1])
 
+    @handle_lastfm_exceptions
     def test_get_artist_play_links(self):
         # Arrange
         artists = ["Portishead", "Radiohead"]
@@ -1028,6 +1109,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIn("spotify:artist:", links[0])
         self.assertIn("spotify:artist:", links[1])
 
+    @handle_lastfm_exceptions
     def test_get_track_play_links(self):
         # Arrange
         track1 = self.network.get_track(artist="Portishead", title="Mysterons")
@@ -1083,6 +1165,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(thing1, expected_type)
         self.assertIsInstance(thing2, expected_type)
 
+    @handle_lastfm_exceptions
     def test_user_get_top_tags_with_limit(self):
         # Arrange
         user = self.network.get_user("RJ")
@@ -1093,6 +1176,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(tags, pylast.Tag)
 
+    @handle_lastfm_exceptions
     def test_network_get_top_artists_with_limit(self):
         # Arrange
         # Act
@@ -1101,6 +1185,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(artists, pylast.Artist)
 
+    @handle_lastfm_exceptions
     def test_network_get_top_tags_with_limit(self):
         # Arrange
         # Act
@@ -1109,6 +1194,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(tags, pylast.Tag)
 
+    @handle_lastfm_exceptions
     def test_network_get_top_tags_with_no_limit(self):
         # Arrange
         # Act
@@ -1117,6 +1203,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_at_least_one_thing_in_top_list(tags, pylast.Tag)
 
+    @handle_lastfm_exceptions
     def test_network_get_top_tracks_with_limit(self):
         # Arrange
         # Act
@@ -1125,6 +1212,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(tracks, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_artist_top_tracks(self):
         # Arrange
         # Pick an artist with plenty of plays
@@ -1136,6 +1224,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_different_things_in_top_list(things, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_artist_top_albums(self):
         # Arrange
         # Pick an artist with plenty of plays
@@ -1147,6 +1236,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_different_things_in_top_list(things, pylast.Album)
 
+    @handle_lastfm_exceptions
     def test_artist_top_fans(self):
         # Arrange
         # Pick an artist with plenty of plays
@@ -1158,6 +1248,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_different_things_in_top_list(things, pylast.User)
 
+    @handle_lastfm_exceptions
     def test_country_top_tracks(self):
         # Arrange
         country = self.network.get_country("Croatia")
@@ -1168,6 +1259,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_different_things_in_top_list(things, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_country_network_top_tracks(self):
         # Arrange
         # Act
@@ -1176,6 +1268,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_different_things_in_top_list(things, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_tag_top_tracks(self):
         # Arrange
         tag = self.network.get_tag("blues")
@@ -1186,6 +1279,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_different_things_in_top_list(things, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_user_top_tracks(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -1219,6 +1313,7 @@ class TestPyLast(unittest.TestCase):
             self.helper_assert_chart(album_chart, pylast.Album)
             self.helper_assert_chart(track_chart, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_group_charts(self):
         # Arrange
         group = self.network.get_group("mnml")
@@ -1228,6 +1323,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_get_assert_charts(group, dates[-2])
 
+    @handle_lastfm_exceptions
     def test_tag_charts(self):
         # Arrange
         tag = self.network.get_tag("rock")
@@ -1237,6 +1333,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_get_assert_charts(tag, dates[-2])
 
+    @handle_lastfm_exceptions
     def test_user_charts(self):
         # Arrange
         lastfm_user = self.network.get_user("RJ")
@@ -1246,6 +1343,7 @@ class TestPyLast(unittest.TestCase):
         # Act/Assert
         self.helper_get_assert_charts(lastfm_user, dates[0])
 
+    @handle_lastfm_exceptions
     def test_track_top_fans(self):
         # Arrange
         track = self.network.get_track("The Cinematic Orchestra", "Postlude")
@@ -1275,6 +1373,7 @@ class TestPyLast(unittest.TestCase):
 
         # album/artist/event/track/user
 
+    @handle_lastfm_exceptions
     def test_album_shouts(self):
         # Arrange
         # Pick an artist with plenty of plays
@@ -1287,6 +1386,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_things_in_list(shouts, pylast.Shout)
 
+    @handle_lastfm_exceptions
     def test_artist_shouts(self):
         # Arrange
         # Pick an artist with plenty of plays
@@ -1298,6 +1398,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_things_in_list(shouts, pylast.Shout)
 
+    @handle_lastfm_exceptions
     def test_event_shouts(self):
         # Arrange
         event_id = 3478520  # Glasto 2014
@@ -1309,6 +1410,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_things_in_list(shouts, pylast.Shout)
 
+    @handle_lastfm_exceptions
     def test_track_shouts(self):
         # Arrange
         track = self.network.get_track("The Cinematic Orchestra", "Postlude")
@@ -1319,6 +1421,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_things_in_list(shouts, pylast.Shout)
 
+    @handle_lastfm_exceptions
     def test_user_shouts(self):
         # Arrange
         user = self.network.get_user("RJ")
@@ -1329,6 +1432,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_two_things_in_list(shouts, pylast.Shout)
 
+    @handle_lastfm_exceptions
     def test_album_data(self):
         # Arrange
         thing = self.network.get_album("Test Artist", "Test Album")
@@ -1350,6 +1454,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(
             "http://www.last.fm/music/test%2bartist/test%2balbum", url)
 
+    @handle_lastfm_exceptions
     def test_track_data(self):
         # Arrange
         thing = self.network.get_track("Test Artist", "Test Title")
@@ -1372,6 +1477,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(
             "http://www.lastfm.fr/music/test%2bartist/_/test%2btitle", url)
 
+    @handle_lastfm_exceptions
     def test_tag_top_artists(self):
         # Arrange
         tag = self.network.get_tag("blues")
@@ -1382,6 +1488,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(artists, pylast.Artist)
 
+    @handle_lastfm_exceptions
     def test_country_top_artists(self):
         # Arrange
         country = self.network.get_country("Ukraine")
@@ -1392,6 +1499,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(artists, pylast.Artist)
 
+    @handle_lastfm_exceptions
     def test_user_top_artists(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -1402,6 +1510,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(artists, pylast.Artist)
 
+    @handle_lastfm_exceptions
     def test_tag_top_albums(self):
         # Arrange
         tag = self.network.get_tag("blues")
@@ -1412,6 +1521,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(albums, pylast.Album)
 
+    @handle_lastfm_exceptions
     def test_user_top_albums(self):
         # Arrange
         user = self.network.get_user("RJ")
@@ -1422,6 +1532,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_top_list(albums, pylast.Album)
 
+    @handle_lastfm_exceptions
     def test_user_tagged_artists(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -1435,6 +1546,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_list(artists, pylast.Artist)
 
+    @handle_lastfm_exceptions
     def test_user_tagged_albums(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -1448,6 +1560,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_list(albums, pylast.Album)
 
+    @handle_lastfm_exceptions
     def test_user_tagged_tracks(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)
@@ -1460,6 +1573,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.helper_only_one_thing_in_list(tracks, pylast.Track)
 
+    @handle_lastfm_exceptions
     def test_caching(self):
         # Arrange
         user = self.network.get_user("RJ")
@@ -1475,6 +1589,7 @@ class TestPyLast(unittest.TestCase):
         self.network.disable_caching()
         self.assertFalse(self.network.is_caching_enabled())
 
+    @handle_lastfm_exceptions
     def test_create_playlist(self):
         # Arrange
         title = "Test playlist"
@@ -1490,6 +1605,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(playlist.get_description(), "Testing")
         self.assertEqual(playlist.get_user(), lastfm_user)
 
+    @handle_lastfm_exceptions
     def test_empty_playlist_unstreamable(self):
         # Arrange
         title = "Empty playlist"
@@ -1503,6 +1619,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(playlist.get_duration(), 0)
         self.assertFalse(playlist.is_streamable())
 
+    @handle_lastfm_exceptions
     def test_big_playlist_is_streamable(self):
         # Arrange
         # Find a big playlist on Last.fm, eg "top 100 classick rock songs"
@@ -1523,6 +1640,7 @@ class TestPyLast(unittest.TestCase):
         self.assertGreater(playlist.get_duration(), 0)
         self.assertTrue(playlist.is_streamable())
 
+    @handle_lastfm_exceptions
     def test_add_track_to_playlist(self):
         # Arrange
         title = "One track playlist"
@@ -1538,6 +1656,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(len(playlist.get_tracks()), 1)
         self.assertTrue(playlist.has_track(track))
 
+    @handle_lastfm_exceptions
     def test_album_mbid(self):
         # Arrange
         mbid = "a6a265bf-9f81-4055-8224-f7ac0aa6b937"
@@ -1551,6 +1670,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(album.title.lower(), "test")
         self.assertEqual(album_mbid, mbid)
 
+    @handle_lastfm_exceptions
     def test_artist_mbid(self):
         # Arrange
         mbid = "7e84f845-ac16-41fe-9ff8-df12eb32af55"
@@ -1562,6 +1682,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(artist, pylast.Artist)
         self.assertEqual(artist.name, "MusicBrainz Test Artist")
 
+    @handle_lastfm_exceptions
     def test_track_mbid(self):
         # Arrange
         mbid = "ebc037b1-cc9c-44f2-a21f-83c219f0e1e0"
@@ -1575,6 +1696,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(track.title, "first")
         self.assertEqual(track_mbid, mbid)
 
+    @handle_lastfm_exceptions
     def test_artist_listener_count(self):
         # Arrange
         artist = self.network.get_artist("Test Artist")
@@ -1586,6 +1708,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(count, int)
         self.assertGreater(count, 0)
 
+    @handle_lastfm_exceptions
     def test_event_attendees(self):
         # Arrange
         user = self.network.get_user("RJ")
@@ -1598,6 +1721,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(users, list)
         self.assertIsInstance(users[0], pylast.User)
 
+    @handle_lastfm_exceptions
     def test_tag_artist(self):
         # Arrange
         artist = self.network.get_artist("Test Artist")
@@ -1616,6 +1740,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertTrue(found)
 
+    @handle_lastfm_exceptions
     def test_remove_tag_of_type_text(self):
         # Arrange
         tag = "testing"  # text
@@ -1634,6 +1759,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertFalse(found)
 
+    @handle_lastfm_exceptions
     def test_remove_tag_of_type_tag(self):
         # Arrange
         tag = pylast.Tag("testing", self.network)  # Tag
@@ -1652,6 +1778,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertFalse(found)
 
+    @handle_lastfm_exceptions
     def test_remove_tags(self):
         # Arrange
         tags = ["removetag1", "removetag2"]
@@ -1675,6 +1802,7 @@ class TestPyLast(unittest.TestCase):
         self.assertFalse(found1)
         self.assertFalse(found2)
 
+    @handle_lastfm_exceptions
     def test_set_tags(self):
         # Arrange
         tags = ["sometag1", "sometag2"]
@@ -1699,6 +1827,7 @@ class TestPyLast(unittest.TestCase):
         self.assertTrue(found1)
         self.assertTrue(found2)
 
+    @handle_lastfm_exceptions
     def test_tracks_notequal(self):
         # Arrange
         track1 = pylast.Track("Test Artist", "Test Title", self.network)
@@ -1708,6 +1837,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertNotEqual(track1, track2)
 
+    @handle_lastfm_exceptions
     def test_track_id(self):
         # Arrange
         track = pylast.Track("Test Artist", "Test Title", self.network)
@@ -1718,6 +1848,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertEqual(id, "14053327")
 
+    @handle_lastfm_exceptions
     def test_track_title_prop_caps(self):
         # Arrange
         track = pylast.Track("test artist", "test title", self.network)
@@ -1728,6 +1859,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertEqual(title, "Test Title")
 
+    @handle_lastfm_exceptions
     def test_track_listener_count(self):
         # Arrange
         track = pylast.Track("test artist", "test title", self.network)
@@ -1738,6 +1870,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertGreater(count, 21)
 
+    @handle_lastfm_exceptions
     def test_album_rel_date(self):
         # Arrange
         album = pylast.Album("Test Artist", "Test Release", self.network)
@@ -1748,6 +1881,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertIn("2011", date)
 
+    @handle_lastfm_exceptions
     def test_album_tracks(self):
         # Arrange
         album = pylast.Album("Test Artist", "Test Release", self.network)
@@ -1760,6 +1894,7 @@ class TestPyLast(unittest.TestCase):
         self.assertIsInstance(tracks[0], pylast.Track)
         self.assertEqual(len(tracks), 4)
 
+    @handle_lastfm_exceptions
     def test_tags(self):
         # Arrange
         tag1 = self.network.get_tag("blues")
@@ -1787,6 +1922,7 @@ class TestPyLast(unittest.TestCase):
                 break
         self.assertTrue(found)
 
+    @handle_lastfm_exceptions
     def test_artists(self):
         # Arrange
         artist1 = self.network.get_artist("Radiohead")
@@ -1810,6 +1946,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(mbid, "a74b1b7f-71a5-4011-9441-d0b5e4122711")
         self.assertIsInstance(streamable, bool)
 
+    @handle_lastfm_exceptions
     def test_events(self):
         # Arrange
         event_id_1 = 3162700  # Glasto 2013
@@ -1844,6 +1981,7 @@ class TestPyLast(unittest.TestCase):
         self.assertGreater(review_count, 0)
         self.assertGreater(attendance_count, 100)
 
+    @handle_lastfm_exceptions
     def test_countries(self):
         # Arrange
         country1 = pylast.Country("Italy", self.network)
@@ -1862,6 +2000,7 @@ class TestPyLast(unittest.TestCase):
         self.assertTrue(country1 != country2)
         self.assertEqual(url, "http://www.last.fm/place/italy")
 
+    @handle_lastfm_exceptions
     def test_track_eq_none_is_false(self):
         # Arrange
         track1 = None
@@ -1870,6 +2009,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertFalse(track1 == track2)
 
+    @handle_lastfm_exceptions
     def test_track_ne_none_is_true(self):
         # Arrange
         track1 = None
@@ -1878,6 +2018,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertTrue(track1 != track2)
 
+    @handle_lastfm_exceptions
     def test_artist_eq_none_is_false(self):
         # Arrange
         artist1 = None
@@ -1886,6 +2027,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertFalse(artist1 == artist2)
 
+    @handle_lastfm_exceptions
     def test_artist_ne_none_is_true(self):
         # Arrange
         artist1 = None
@@ -1894,6 +2036,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertTrue(artist1 != artist2)
 
+    @handle_lastfm_exceptions
     def test_album_eq_none_is_false(self):
         # Arrange
         album1 = None
@@ -1902,6 +2045,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertFalse(album1 == album2)
 
+    @handle_lastfm_exceptions
     def test_album_ne_none_is_true(self):
         # Arrange
         album1 = None
@@ -1910,6 +2054,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertTrue(album1 != album2)
 
+    @handle_lastfm_exceptions
     def test_event_eq_none_is_false(self):
         # Arrange
         event1 = None
@@ -1919,6 +2064,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertFalse(event1 == event2)
 
+    @handle_lastfm_exceptions
     def test_event_ne_none_is_true(self):
         # Arrange
         event1 = None
@@ -1928,6 +2074,7 @@ class TestPyLast(unittest.TestCase):
         # Act / Assert
         self.assertTrue(event1 != event2)
 
+    @handle_lastfm_exceptions
     def test_band_members(self):
         # Arrange
         artist = pylast.Artist("The Beatles", self.network)
@@ -1938,6 +2085,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertGreaterEqual(len(band_members), 4)
 
+    @handle_lastfm_exceptions
     def test_no_band_members(self):
         # Arrange
         artist = pylast.Artist("John Lennon", self.network)
@@ -1948,6 +2096,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertIsNone(band_members)
 
+    @handle_lastfm_exceptions
     def test_get_recent_tracks_from_to(self):
         # Arrange
         lastfm_user = self.network.get_user("RJ")
@@ -1968,6 +2117,7 @@ class TestPyLast(unittest.TestCase):
         self.assertEqual(str(tracks[0].track.artist), "Johnny Cash")
         self.assertEqual(str(tracks[0].track.title), "Ring of Fire")
 
+    @handle_lastfm_exceptions
     def test_artist_get_correction(self):
         # Arrange
         artist = pylast.Artist("guns and roses", self.network)
@@ -1978,6 +2128,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertEqual(corrected_artist_name, "Guns N' Roses")
 
+    @handle_lastfm_exceptions
     def test_track_get_correction(self):
         # Arrange
         track = pylast.Track("Guns N' Roses", "mrbrownstone", self.network)
@@ -1988,6 +2139,7 @@ class TestPyLast(unittest.TestCase):
         # Assert
         self.assertEqual(corrected_track_name, "Mr. Brownstone")
 
+    @handle_lastfm_exceptions
     def test_track_with_no_mbid(self):
         # Arrange
         track = pylast.Track("Static-X", "Set It Off", self.network)


### PR DESCRIPTION
Specifically skip those that cause the exception `pylast.WSError` "Invalid Method - No method with that name in this package".

Last.fm broke these some time around 17th August 2015 when they relaunched ("re-imagined") their website.