### PR TITLE
Fix build: no such option: --download-cache

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py34, py27, pypy, pypy3
 recreate = False
 
 [testenv]
-downloadcache = {homedir}/.pipcache
 setenv =
     PYLAST_USERNAME={env:PYLAST_USERNAME:}
     PYLAST_PASSWORD_HASH={env:PYLAST_PASSWORD_HASH:}


### PR DESCRIPTION
Travis started [failing during installation](https://travis-ci.org/pylast/pylast/jobs/107969481) (which was [working before](https://travis-ci.org/pylast/pylast/jobs/98505653)) with:

```
lint installdeps: coverage, pep8, pyyaml, pyflakes, clonedigger
ERROR: invocation failed (exit code 2), logfile: /home/travis/build/pylast/pylast/.tox/lint/log/lint-1.log
ERROR: actionid: lint
msg: getenv
cmdargs: [local('/home/travis/build/pylast/pylast/.tox/lint/bin/pip'), 'install', '--download-cache=/home/travis/.pipcache', 'coverage', 'pep8', 'pyyaml', 'pyflakes', 'clonedigger']
env: {'PYLAST_API_SECRET': '', 'rvm_version': '1.26.8 (1.26.8)', 'LC_CTYPE': 'en_US.UTF-8', 'RUBY_VERSION': 'ruby-1.9.3-p551', 'MERB_ENV': 'test', 'NVM_DIR': '/home/travis/.nvm', 'TRAVIS_REPO_SLUG': 'pylast/pylast', 'HOME': '/home/travis', 'TRAVIS_PULL_REQUEST': '153', 'LANG': 'en_US.UTF-8', 'JRUBY_OPTS': '--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false', 'VIRTUAL_ENV': '/home/travis/build/pylast/pylast/.tox/lint', 'SHELL': '/bin/bash', 'TRAVIS_COMMIT': '1b4b8c53c470b49ed8d548f90a99110a801211d2', 'TRAVIS_BRANCH': 'develop', 'rvm_with_default_gems': 'rake=~>10.2.2 bundler=~>1.6.0', 'NVM_BIN': '/home/travis/.nvm/v0.10.36/bin', 'NVM_PATH': '/home/travis/.nvm/v0.10.36/lib/node', 'VIRTUAL_ENV_DISABLE_PROMPT': 'true', 'MANPATH': '/home/travis/.nvm/v0.10.36/share/man:/usr/local/clang-3.4/share/man:/usr/local/man:/usr/local/share/man:/usr/share/man', '_system_arch': 'x86_64', 'CI': 'true', 'TOXENV': 'lint', 'rvm_loaded_flag': '1', 'rvm_prefix': '/home/travis', 'DEBIAN_FRONTEND': 'noninteractive', 'rvm_user_install_flag': '1', 'IRBRC': '/home/travis/.rvm/rubies/ruby-1.9.3-p551/.irbrc', 'TRAVIS_BUILD_ID': '107969480', 'TRAVIS_SECURE_ENV_VARS': 'false', 'MY_RUBY_HOME': '/home/travis/.rvm/rubies/ruby-1.9.3-p551', 'rvm_max_time_flag': '5', 'PYLAST_API_KEY': '', 'JAVA_HOME': '/usr/lib/jvm/java-7-oracle', 'TRAVIS': 'true', 'SSH_TTY': '/dev/pts/1', '_system_version': '12.04', 'PIP_DISABLE_PIP_VERSION_CHECK': '1', 'TRAVIS_COMMIT_RANGE': '9924500108a5ff58cd766da5aeaac4621c6e8f68...37fdc1fe806d018ce7d641a06c9e5af925b0189e', 'MAIL': '/var/mail/travis', 'rvm_bin_path': '/home/travis/.rvm/bin', 'GEM_HOME': '/home/travis/.rvm/gems/ruby-1.9.3-p551', 'HAS_JOSH_K_SEAL_OF_APPROVAL': 'true', 'NVM_NODEJS_ORG_MIRROR': 'https://nodejs.org/dist', 'PYTHON_CFLAGS': '-g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security', 'PYLAST_USERNAME': '', 'COMPOSER_NO_INTERACTION': '1', 'TRAVIS_LANGUAGE': 'python', 'CONTINUOUS_INTEGRATION': 'true', 'GOROOT': '/home/travis/.gimme/versions/go1.4.1.linux.amd64', 'rvm_path': '/home/travis/.rvm', 'RACK_ENV': 'test', 'SSH_CLIENT': '172.17.42.1 49283 22', 'rvm_project_rvmrc': '0', 'LOGNAME': 'travis', 'USER': 'travis', 'PATH': '/home/travis/build/pylast/pylast/.tox/lint/bin:/home/travis/virtualenv/python2.7.9/bin:/home/travis/bin:/home/travis/.local/bin:/home/travis/.gimme/versions/go1.4.1.linux.amd64/bin:/opt/python/2.7.9/bin:/opt/python/2.6.9/bin:/opt/python/3.4.2/bin:/opt/python/3.3.5/bin:/opt/python/3.2.5/bin:/opt/python/pypy-2.5.0/bin:/opt/python/pypy3-2.4.0/bin:/usr/local/phantomjs/bin:/home/travis/.nvm/v0.10.36/bin:./node_modules/.bin:/usr/local/maven-3.2.5/bin:/usr/local/clang-3.4/bin:/home/travis/.gimme/versions/go1.4.1.linux.amd64/bin:/opt/python/2.7.9/bin:/opt/python/2.6.9/bin:/opt/python/3.4.2/bin:/opt/python/3.3.5/bin:/opt/python/3.2.5/bin:/opt/python/pypy-2.5.0/bin:/opt/python/pypy3-2.4.0/bin:/usr/local/phantomjs/bin:./node_modules/.bin:/usr/local/maven-3.2.5/bin:/usr/local/clang-3.4/bin:/home/travis/.gimme/versions/go1.4.1.linux.amd64/bin:/home/travis/.rvm/gems/ruby-1.9.3-p551/bin:/home/travis/.rvm/gems/ruby-1.9.3-p551@global/bin:/home/travis/.rvm/rubies/ruby-1.9.3-p551/bin:/opt/python/2.7.9/bin:/opt/python/2.6.9/bin:/opt/python/3.4.2/bin:/opt/python/3.3.5/bin:/opt/python/3.2.5/bin:/opt/python/pypy-2.5.0/bin:/opt/python/pypy3-2.4.0/bin:/usr/local/phantomjs/bin:./node_modules/.bin:/usr/local/maven-3.2.5/bin:/usr/local/clang-3.4/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/travis/.rvm/bin:/home/travis/.rvm/bin:/home/travis/.rvm/bin', 'rvm_silence_path_mismatch_check_flag': '1', 'NVM_IOJS_ORG_MIRROR': 'https://iojs.org/dist', 'rvm_autoupdate_flag': '0', 'PYLAST_PASSWORD_HASH': '', 'PS4': '+', 'TERM': 'xterm', 'SHLVL': '3', '_system_name': 'Ubuntu', 'NVM_IOJS_ORG_VERSION_LISTING': 'https://iojs.org/dist/index.tab', 'GIT_ASKPASS': 'echo', 'PYTHONHASHSEED': '116792177', 'GEM_PATH': '/home/travis/.rvm/gems/ruby-1.9.3-p551:/home/travis/.rvm/gems/ruby-1.9.3-p551@global', 'HAS_ANTARES_THREE_LITTLE_FRONZIES_BADGE': 'true', 'RAILS_ENV': 'test', 'TRAVIS_JOB_NUMBER': '241.1', 'PYTHON_CONFIGURE_OPTS': '--enable-unicode=ucs4 --with-wide-unicode --enable-shared --enable-ipv6 --enable-loadable-sqlite-extensions --with-computed-gotos', 'rvm_stored_umask': '0002', 'LC_ALL': 'en_US.UTF-8', '_system_type': 'Linux', '_': '/home/travis/virtualenv/python2.7.9/bin/tox', 'TRAVIS_TAG': '', 'TRAVIS_JOB_ID': '107969481', 'SSH_CONNECTION': '172.17.42.1 49283 172.17.6.18 22', 'TRAVIS_PYTHON_VERSION': '2.7', 'OLDPWD': '/home/travis/build', 'rvm_without_gems': 'rubygems-bundler', 'TRAVIS_BUILD_NUMBER': '241', 'TRAVIS_BUILD_DIR': '/home/travis/build/pylast/pylast', 'PWD': '/home/travis/build/pylast/pylast', 'TRAVIS_OS_NAME': 'linux'}
Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...
no such option: --download-cache
ERROR: could not install deps [coverage, pep8, pyyaml, pyflakes, clonedigger]; v = InvocationError('/home/travis/build/pylast/pylast/.tox/lint/bin/pip install --download-cache=/home/travis/.pipcache coverage pep8 pyyaml pyflakes clonedigger (see /home/travis/build/pylast/pylast/.tox/lint/log/lint-1.log)', 2)
___________________________________ summary ____________________________________
ERROR:   lint: could not install deps [coverage, pep8, pyyaml, pyflakes, clonedigger]; v = InvocationError('/home/travis/build/pylast/pylast/.tox/lint/bin/pip install --download-cache=/home/travis/.pipcache coverage pep8 pyyaml pyflakes clonedigger (see /home/travis/build/pylast/pylast/.tox/lint/log/lint-1.log)', 2)
The command "tox" exited with 1.
Done. Your build exited with 1.
```

See https://github.com/django-compressor/django-compressor/issues/729 for more info.
