### PR TITLE
Skip broken tests caused by the broken Last.fm API

### DIFF
--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -210,6 +210,10 @@ class TestPyLast(unittest.TestCase):
         registered = user.get_registered()
 
         # Assert
+        # Last.fm API broken? Should be yyyy-mm-dd not Unix timestamp
+        if int(registered):
+            pytest.skip("Last.fm API is broken.")
+
         # Just check date because of timezones
         self.assertIn(u"2002-11-20 ", registered)
 
@@ -1912,7 +1916,6 @@ class TestPyLast(unittest.TestCase):
         tag_repr = repr(tag1)
         tag_str = str(tag1)
         name = tag1.get_name(properly_capitalized=True)
-        similar = tag1.get_similar()
         url = tag1.get_url()
 
         # Assert
@@ -1923,6 +1926,16 @@ class TestPyLast(unittest.TestCase):
         self.assertTrue(tag1 == tag1)
         self.assertTrue(tag1 != tag2)
         self.assertEqual(url, "http://www.last.fm/tag/blues")
+
+    @handle_lastfm_exceptions
+    def test_tags_similar(self):
+        # Arrange
+        tag = self.network.get_tag("blues")
+
+        # Act
+        similar = tag.get_similar()
+
+        # Assert
         found = False
         for tag in similar:
             if tag.name == "delta blues":

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -70,7 +70,7 @@ class TestPyLast(unittest.TestCase):
 
     def skip_if_lastfm_api_broken(self, value):
         """Skip things not yet restored in Last.fm's broken API"""
-        if value is None:
+        if value is None or len(value) == 0:
             pytest.skip("Last.fm API is broken.")
 
     @handle_lastfm_exceptions
@@ -926,7 +926,8 @@ class TestPyLast(unittest.TestCase):
         lastfm_user = self.network.get_authenticated_user()
 
         # Act/Assert
-        self.helper_validate_cacheable(lastfm_user, "get_friends")
+        # Skip the first one because Last.fm API is broken
+        # self.helper_validate_cacheable(lastfm_user, "get_friends")
         self.helper_validate_cacheable(lastfm_user, "get_loved_tracks")
         self.helper_validate_cacheable(lastfm_user, "get_neighbours")
         self.helper_validate_cacheable(lastfm_user, "get_past_events")
@@ -1184,6 +1185,7 @@ class TestPyLast(unittest.TestCase):
         tags = user.get_top_tags(limit=1)
 
         # Assert
+        self.skip_if_lastfm_api_broken(tags)
         self.helper_only_one_thing_in_top_list(tags, pylast.Tag)
 
     @handle_lastfm_exceptions
@@ -1936,8 +1938,7 @@ class TestPyLast(unittest.TestCase):
         similar = tag.get_similar()
 
         # Assert
-        if len(similar) == 0:
-            pytest.skip("Last.fm API is broken.")
+        self.skip_if_lastfm_api_broken(similar)
         found = False
         for tag in similar:
             if tag.name == "delta blues":

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -68,6 +68,11 @@ class TestPyLast(unittest.TestCase):
             api_key=API_KEY, api_secret=API_SECRET,
             username=self.username, password_hash=password_hash)
 
+    def skip_if_lastfm_api_broken(self, value):
+        """Skip things not yet restored in Last.fm's broken API"""
+        if value is None:
+            pytest.skip("Last.fm API is broken.")
+
     @handle_lastfm_exceptions
     def test_scrobble(self):
         # Arrange
@@ -530,6 +535,7 @@ class TestPyLast(unittest.TestCase):
         total = search.get_total_result_count()
 
         # Assert
+        self.skip_if_lastfm_api_broken(total)
         self.assertGreaterEqual(int(total), 0)
 
     @handle_lastfm_exceptions
@@ -1846,6 +1852,7 @@ class TestPyLast(unittest.TestCase):
         id = track.get_id()
 
         # Assert
+        self.skip_if_lastfm_api_broken(id)
         self.assertEqual(id, "14053327")
 
     @handle_lastfm_exceptions
@@ -1879,6 +1886,7 @@ class TestPyLast(unittest.TestCase):
         date = album.get_release_date()
 
         # Assert
+        self.skip_if_lastfm_api_broken(date)
         self.assertIn("2011", date)
 
     @handle_lastfm_exceptions
@@ -2083,6 +2091,7 @@ class TestPyLast(unittest.TestCase):
         band_members = artist.get_band_members()
 
         # Assert
+        self.skip_if_lastfm_api_broken(band_members)
         self.assertGreaterEqual(len(band_members), 4)
 
     @handle_lastfm_exceptions

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -1936,6 +1936,8 @@ class TestPyLast(unittest.TestCase):
         similar = tag.get_similar()
 
         # Assert
+        if len(similar) == 0:
+            pytest.skip("Last.fm API is broken.")
         found = False
         for tag in similar:
             if tag.name == "delta blues":


### PR DESCRIPTION
Last.fm broke these some time around 17th August 2015 when they relaunched ("re-imagined") their website.

Some of these are still documented in the trimmed [Last.fm API docs](http://www.last.fm/api), but the live XML examples are missing certain attributes or return the wrong thing or are just broken.

See also https://github.com/pylast/pylast/pull/164.

--

[Current test status (Python 2.7/Travis CI):](https://travis-ci.org/hugovk/pylast/jobs/125216202) 

`=================== 99 passed, 59 skipped in 229.55 seconds ====================`
