### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
       env: TOXENV=py35
     - python: 3.4
       env: TOXENV=py34
-    - python: 3.3
-      env: TOXENV=py33
     - python: pypy3
       env: TOXENV=pypy3
     - python: pypy

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 pyLast
 ======
 
-[![Build status](https://travis-ci.org/pylast/pylast.svg?branch=develop)](https://travis-ci.org/pylast/pylast) 
-[![PyPI version](https://img.shields.io/pypi/v/pylast.svg)](https://pypi.python.org/pypi/pylast/) 
+[![Build status](https://travis-ci.org/pylast/pylast.svg?branch=develop)](https://travis-ci.org/pylast/pylast)
+[![PyPI version](https://img.shields.io/pypi/v/pylast.svg)](https://pypi.python.org/pypi/pylast/)
 <!--[![PyPI downloads](https://img.shields.io/pypi/dm/pylast.svg)](https://pypi.python.org/pypi/pylast/)-->
 [![Coverage (Codecov)](https://codecov.io/gh/pylast/pylast/branch/develop/graph/badge.svg)](https://codecov.io/gh/pylast/pylast)
 [![Coverage (Coveralls)](https://coveralls.io/repos/github/pylast/pylast/badge.svg?branch=develop)](https://coveralls.io/github/pylast/pylast?branch=develop)
@@ -20,6 +20,7 @@ Install via pip:
 
     pip install pylast
 
+pyLast >= 2.0.0 supports Python 2.7.9+ and 3.4+.
 
 Features
 --------

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,6 @@ setup(
     version="1.9.0",
     author="Amr Hassan <amr.hassan@gmail.com>",
     install_requires=['six'],
-    # FIXME This can be removed after 2017-09 when 3.3 is no longer supported
-    # and pypy3 uses 3.4 or later, see
-    # https://en.wikipedia.org/wiki/CPython#Version_history
-    extras_require={
-        ':python_version=="3.3"': ["certifi"],
-    },
     tests_require=['mock', 'pytest', 'coverage', 'pep8', 'pyyaml', 'pyflakes'],
     description=("A Python interface to Last.fm and Libre.fm"),
     author_email="amr.hassan@gmail.com",
@@ -26,10 +20,11 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     keywords=["Last.fm", "music", "scrobble", "scrobbling"],
     packages=find_packages(exclude=('tests*',)),


### PR DESCRIPTION
CPython 3.3 is no longer supported after September 29, 2017.

https://en.wikipedia.org/wiki/CPython#Version_history
https://www.python.org/dev/peps/pep-0398/