### PR TITLE
Fix unclosed SSLSocket warning

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -33,8 +33,9 @@ import time
 import xml.dom
 
 __version__ = '1.9.0'
-__author__ = 'Amr Hassan, hugovk'
-__copyright__ = "Copyright (C) 2008-2010 Amr Hassan, 2013-2017 hugovk"
+__author__ = 'Amr Hassan, hugovk, Mice Pápai'
+__copyright__ = ('Copyright (C) 2008-2010 Amr Hassan, 2013-2017 hugovk, '
+                 '2017 Mice Pápai')
 __license__ = "apache2"
 __email__ = 'amr.hassan@gmail.com'
 
@@ -1048,6 +1049,7 @@ class _Request(object):
         response_text = XML_ILLEGAL.sub("?", response_text)
 
         self._check_response_for_errors(response_text)
+        conn.close()
         return response_text
 
     def execute(self, cacheable=False):

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -1803,7 +1803,7 @@ class TestPyLast(unittest.TestCase):
     def test_set_tags(self):
         # Arrange
         tags = ["sometag1", "sometag2"]
-        artist = self.network.get_artist("Test Artist")
+        artist = self.network.get_artist("Test Artist 2")
         artist.add_tags(tags)
         tags_before = artist.get_tags()
         new_tags = ["settag1", "settag2"]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
      ipdb
      pytest-cov
      flaky
-commands = py.test -v --cov pylast --cov-report term-missing {posargs}
+commands = py.test -v -s -W all --cov pylast --cov-report term-missing {posargs}
 
 [testenv:venv]
 deps = ipdb


### PR DESCRIPTION
Cherry-picked from #200, after enabling output of warnings on Travis CI.

Before the fix, 297 `ResourceWarning`s on Python 3.6:
```
tests/test_pylast.py::TestPyLast::test_add_album
  /home/travis/build/pylast/pylast/pylast/__init__.py:1059: ResourceWarning: unclosed <ssl.SSLSocket fd=4, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('172.17.0.7', 33318), raddr=('64.30.224.206', 443)>
    response = self._download_response()
```
https://travis-ci.org/pylast/pylast/jobs/276818610#L791

After, just one:
```
tests/test_pylast.py::TestPyLast::test_init_with_token
  /home/travis/build/pylast/pylast/tests/test_pylast.py:2172: ResourceWarning: unclosed <ssl.SSLSocket fd=44, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('172.17.0.11', 47804), raddr=('64.30.224.206', 443)>
    msg = str(exc)
```
https://travis-ci.org/pylast/pylast/jobs/276819172#L787

---

Also, unrelated: use different artists for test_set_tags and test_remove_tags to avoid parallel test collisions.


