### PR TITLE
Fix: _collect_nodes() break if there are no child nodes

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -3984,6 +3984,9 @@ def _collect_nodes(limit, sender, method_name, cacheable, params=None):
         doc = sender._request(method_name, cacheable, params)
         doc = cleanup_nodes(doc)
 
+        # break if there are no child nodes
+        if not doc.documentElement.childNodes:
+            break
         main = doc.documentElement.childNodes[0]
 
         if main.hasAttribute("totalPages"):

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -911,8 +911,7 @@ class TestPyLast(unittest.TestCase):
         lastfm_user = self.network.get_authenticated_user()
 
         # Act/Assert
-        # Skip the first one because Last.fm API is broken
-        # self.helper_validate_cacheable(lastfm_user, "get_friends")
+        self.helper_validate_cacheable(lastfm_user, "get_friends")
         self.helper_validate_cacheable(lastfm_user, "get_loved_tracks")
         self.helper_validate_cacheable(lastfm_user, "get_neighbours")
         self.helper_validate_cacheable(lastfm_user, "get_past_events")


### PR DESCRIPTION
Cherry-picked from #200.