### PR TITLE
Remove redundant code

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -3195,9 +3195,6 @@ class User(_BaseObject, _Chartable):
 
         This method uses caching. Enable caching only if you're pulling a
         large amount of data.
-
-        Use extract_items() with the return of this function to
-        get only a sequence of Track objects with no playback dates.
         """
 
         params = self._get_params()
@@ -3312,9 +3309,6 @@ class User(_BaseObject, _Chartable):
 
         This method uses caching. Enable caching only if you're pulling a
         large amount of data.
-
-        Use extract_items() with the return of this function to
-        get only a sequence of Track objects with no playback dates.
         """
 
         params = self._get_params()
@@ -4119,19 +4113,6 @@ def _unescape_htmlentity(string):
         string = string.replace("&%s;" % key, unichr(mapping[key]))
 
     return string
-
-
-def extract_items(top_items_or_library_items):
-    """
-    Extracts a sequence of items from a sequence of TopItem or
-    LibraryItem objects.
-    """
-
-    seq = []
-    for i in top_items_or_library_items:
-        seq.append(i.item)
-
-    return seq
 
 
 # End of file

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2462,10 +2462,6 @@ class Library(_BaseObject):
         else:
             self.user = User(user, self.network)
 
-        self._albums_index = 0
-        self._artists_index = 0
-        self._tracks_index = 0
-
     def __repr__(self):
         return "pylast.Library(%s, %s)" % (repr(self.user), repr(self.network))
 
@@ -3119,10 +3115,6 @@ class User(_BaseObject, _Chartable):
         _Chartable.__init__(self, 'user')
 
         self.name = user_name
-
-        self._past_events_index = 0
-        self._recommended_events_index = 0
-        self._recommended_artists_index = 0
 
     def __repr__(self):
         return "pylast.User(%s, %s)" % (repr(self.name), repr(self.network))

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1200,17 +1200,6 @@ def _string_output(func):
     return r
 
 
-def _pad_list(given_list, desired_length, padding=None):
-    """
-        Pads a list to be of the desired_length.
-    """
-
-    while len(given_list) < desired_length:
-        given_list.append(padding)
-
-    return given_list
-
-
 class _BaseObject(object):
     """An abstract webservices object."""
 

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -139,8 +139,7 @@ class _Network(object):
 
     def __init__(
             self, name, homepage, ws_server, api_key, api_secret, session_key,
-            submission_server, username, password_hash, domain_names, urls,
-            token=None):
+            username, password_hash, domain_names, urls, token=None):
         """
             name: the name of the network
             homepage: the homepage URL
@@ -148,8 +147,6 @@ class _Network(object):
             api_key: a provided API_KEY
             api_secret: a provided API_SECRET
             session_key: a generated session_key or None
-            submission_server: the URL of the server to which tracks are
-                submitted (scrobbled)
             username: a username of a valid user
             password_hash: the output of pylast.md5(password) where password is
                 the user's password
@@ -175,7 +172,6 @@ class _Network(object):
         self.api_key = api_key
         self.api_secret = api_secret
         self.session_key = session_key
-        self.submission_server = submission_server
         self.username = username
         self.password_hash = password_hash
         self.domain_names = domain_names
@@ -797,7 +793,6 @@ class LastFMNetwork(_Network):
             api_key=api_key,
             api_secret=api_secret,
             session_key=session_key,
-            submission_server="http://post.audioscrobbler.com:80/",
             username=username,
             password_hash=password_hash,
             token=token,
@@ -864,7 +859,6 @@ class LibreFMNetwork(_Network):
             api_key=api_key,
             api_secret=api_secret,
             session_key=session_key,
-            submission_server="http://turtle.libre.fm:80/",
             username=username,
             password_hash=password_hash,
             domain_names={

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2237,12 +2237,6 @@ class Country(_BaseObject):
     def _get_params(self):  # TODO can move to _BaseObject
         return {'country': self.get_name()}
 
-    def _get_name_from_code(self, alpha2code):
-        # TODO: Have this function lookup the alpha-2 code and return the
-        # country name.
-
-        return alpha2code
-
     def get_name(self):
         """Returns the country name. """
 

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -1564,11 +1564,48 @@ class TestPyLast(unittest.TestCase):
         tags = ["tracktagola"]
         track = self.network.get_track("Test Artist", "test title")
         track.add_tags(tags)
+
         # Act
         tracks = lastfm_user.get_tagged_tracks('tracktagola', limit=1)
 
         # Assert
         self.helper_only_one_thing_in_list(tracks, pylast.Track)
+
+    @handle_lastfm_exceptions
+    def test_user_subscriber(self):
+        # Arrange
+        subscriber = self.network.get_user("RJ")
+        non_subscriber = self.network.get_user("Test User")
+
+        # Act
+        subscriber_is_subscriber = subscriber.is_subscriber()
+        non_subscriber_is_subscriber = non_subscriber.is_subscriber()
+
+        # Assert
+        self.assertTrue(subscriber_is_subscriber)
+        self.assertFalse(non_subscriber_is_subscriber)
+
+    @handle_lastfm_exceptions
+    def test_user_get_image(self):
+        # Arrange
+        user = self.network.get_user("RJ")
+
+        # Act
+        url = user.get_image()
+
+        # Assert
+        self.assertTrue(url.startswith("https://"))
+
+    @handle_lastfm_exceptions
+    def test_user_get_library(self):
+        # Arrange
+        user = self.network.get_user(self.username)
+
+        # Act
+        library = user.get_library()
+
+        # Assert
+        self.assertIsInstance(library, pylast.Library)
 
     @handle_lastfm_exceptions
     def test_caching(self):


### PR DESCRIPTION
* Continuation of #211, #218 and #222: the only place`submission_server` was used was removed in #218.

* Remove `_get_name_from_code`, it was never finished and can be implemented outside the scope of pylast.

* The six removed attributes aren't used anywhere and date from at least pylast 0.5.

* `_pad_list` is unused, internal, and not so useful.

* `extract_items` is unused. I added tests but it wasn't working, so let's just remove it as I don't think it's so useful.

* Test a few previously untested things.