### PR TITLE
Fix search.get_total_result_count()

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
   Apache License
 Version 2.0, January 2004
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -830,7 +830,7 @@ class _Request(object):
 
             try:
                 conn.request(
-                    method='POST', url="http://" + HOST_NAME + HOST_SUBDIR,
+                    method='POST', url="https://" + HOST_NAME + HOST_SUBDIR,
                     body=data, headers=headers)
             except Exception as e:
                 raise NetworkError(self.network, e)

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2483,7 +2483,7 @@ class _Search(_BaseObject):
 
         doc = self._request(self._ws_prefix + ".search", True)
 
-        return _extract(doc, "opensearch:totalResults")
+        return _extract(doc, "totalResults")
 
     def _retrieve_page(self, page_index):
         """Returns the node of matches to be processed"""

--- a/tests/test_pylast_artist.py
+++ b/tests/test_pylast_artist.py
@@ -213,7 +213,7 @@ class TestPyLastArtist(PyLastTestCase):
         name_cap = artist1.get_name(properly_capitalized=True)
 
         # Assert
-        self.assertIn("http", image)
+        self.assertIn("https", image)
         self.assertGreater(playcount, 1)
         self.assertTrue(artist1 != artist2)
         self.assertEqual(name.lower(), name_cap.lower())

--- a/tests/test_pylast_network.py
+++ b/tests/test_pylast_network.py
@@ -339,6 +339,18 @@ class TestPyLastNetwork(PyLastTestCase):
         self.assertIsInstance(results, list)
         self.assertIsInstance(results[0], pylast.Track)
 
+    def test_search_get_total_result_count(self):
+        # Arrange
+        artist = "Nirvana"
+        track = "Smells Like Teen Spirit"
+        search = self.network.search_for_track(artist, track)
+
+        # Act
+        total = search.get_total_result_count()
+
+        # Assert
+        self.assertGreater(int(total), 10000)
+
 
 if __name__ == '__main__':
     unittest.main(failfast=True)


### PR DESCRIPTION
```
This page contains the following errors:

error on line 2 at column 73: Namespace prefix opensearch on Query is not defined
error on line 3 at column 25: Namespace prefix opensearch on totalResults is not defined
error on line 4 at column 23: Namespace prefix opensearch on startIndex is not defined
error on line 5 at column 25: Namespace prefix opensearch on itemsPerPage is not defined
Below is a rendering of the page up to the first error.
```
![image](https://user-images.githubusercontent.com/1324225/31913796-f357c2f0-b850-11e7-9708-d9eb73734562.png)

https://www.last.fm/api/show/track.search
https://ws.audioscrobbler.com/2.0/?method=track.search&track=Believe&api_key=ENTER_YOUR_API_KEY

This was worked around in https://github.com/pylast/pylast/issues/152 by removing the malformed "opensearch:" prefix. 

(Temporarily removing that gives `pylast.MalformedResponseError: Malformed response from Last.fm. Underlying error: unbound prefix: line 2, column 26`, so it's still needed.)

So fix `search.get_total_result_count()` to get the value is from `totalResults` not `opensearch:totalResults`.

---

Plus some http -> https.