### PR TITLE
Return unix timestamp as int

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2288,8 +2288,8 @@ class User(_BaseObject, _Chartable):
 
         doc = self._request(self.ws_prefix + ".getInfo", True)
 
-        return doc.getElementsByTagName(
-            "registered")[0].getAttribute("unixtime")
+        return int(doc.getElementsByTagName(
+            "registered")[0].getAttribute("unixtime"))
 
     def get_tagged_albums(self, tag, limit=None, cacheable=True):
         """Returns the albums tagged by a user."""

--- a/tests/test_pylast_user.py
+++ b/tests/test_pylast_user.py
@@ -87,7 +87,7 @@ class TestPyLastUser(PyLastTestCase):
 
         # Assert
         # Just check date because of timezones
-        self.assertEqual(unixtime_registered, u"1037793040")
+        self.assertEqual(unixtime_registered, 1037793040)
 
     def test_get_countryless_user(self):
         # Arrange


### PR DESCRIPTION
Unix timestamps are currently returned as strings. I'd argue that while this behaviour is true to the `xml` schema it doesn't make much sense. 
```xml
<registered unixtime="1037793040">2002-11-20 11:50</registered>
```
They even kind of acknowledged this in the `json` schema. (Probably because someone at last realized that it doesn't make any sense to do date conversion in the API)
```json
registered: {
    "#text": 1037793040,
    "unixtime": "1037793040"
}
```

I don't know if a simple "cast" to int is the right choice here, even if the string returned by the API should always be a number. Should I add any additional validation to prevent a possible crash?