### PR TITLE
Update python_requires to 2.7.10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7.10, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     keywords=["Last.fm", "music", "scrobble", "scrobbling"],
     packages=find_packages(exclude=('tests*',)),
     license="Apache2"


### PR DESCRIPTION
Fixes https://github.com/pylast/pylast/issues/239. 

Update python_requires to specify the exact x.y.z 2.7.10 version required.

(From HTTPS changes in #178.)