### PR TITLE
Use paging to get all 'limit' items for Artist.get_top_albums

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1046,11 +1046,14 @@ class _BaseObject(object):
             self, method, thing, thing_type, params=None, cacheable=True):
         """Returns a list of the most played thing_types by this thing."""
 
-        doc = self._request(
-            self.ws_prefix + "." + method, cacheable, params)
-
+        limit = params.get("limit", 1)
         seq = []
-        for node in doc.getElementsByTagName(thing):
+        for node in _collect_nodes(
+                limit,
+                self,
+                self.ws_prefix + "." + method,
+                cacheable,
+                params):
             title = _extract(node, "name")
             artist = _extract(node, "name", 1)
             playcount = _number(_extract(node, "playcount"))

--- a/tests/test_pylast_artist.py
+++ b/tests/test_pylast_artist.py
@@ -86,6 +86,42 @@ class TestPyLastArtist(PyLastTestCase):
         # Assert
         self.helper_two_different_things_in_top_list(things, pylast.Album)
 
+    def test_artist_top_albums_limit_1(self):
+        # Arrange
+        limit = 1
+        # Pick an artist with plenty of plays
+        artist = self.network.get_top_artists(limit=1)[0].item
+
+        # Act
+        things = artist.get_top_albums(limit=limit)
+
+        # Assert
+        self.assertEqual(len(things), 1)
+
+    def test_artist_top_albums_limit_50(self):
+        # Arrange
+        limit = 50
+        # Pick an artist with plenty of plays
+        artist = self.network.get_top_artists(limit=1)[0].item
+
+        # Act
+        things = artist.get_top_albums(limit=limit)
+
+        # Assert
+        self.assertEqual(len(things), 50)
+
+    def test_artist_top_albums_limit_100(self):
+        # Arrange
+        limit = 100
+        # Pick an artist with plenty of plays
+        artist = self.network.get_top_artists(limit=1)[0].item
+
+        # Act
+        things = artist.get_top_albums(limit=limit)
+
+        # Assert
+        self.assertEqual(len(things), 100)
+
     def test_artist_listener_count(self):
         # Arrange
         artist = self.network.get_artist("Test Artist")


### PR DESCRIPTION
Fixes #242.

`Artist.get_top_albums` with `limit=100` returns 100 per page for some artists, but only returns 50 per page for others.

Use paging to load as many pages as needed to return the required limit.