### PR TITLE
Simplify version checking

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -39,17 +39,16 @@ __license__ = "apache2"
 __email__ = 'amr.hassan@gmail.com'
 
 
-if sys.version_info.major == 3:
-    import html.entities as htmlentitydefs
-    from http.client import HTTPSConnection
-    from urllib.parse import quote_plus as url_quote_plus
-
-    unichr = chr
-
-elif sys.version_info.major == 2:
+if sys.version_info.major == 2:
     import htmlentitydefs
     from httplib import HTTPSConnection
     from urllib import quote_plus as url_quote_plus
+else:
+    import html.entities as htmlentitydefs
+    from http.client import HTTPSConnection
+    from urllib.parse import quote_plus as url_quote_plus
+    unichr = chr
+
 
 STATUS_INVALID_SERVICE = 2
 STATUS_INVALID_METHOD = 3

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -39,14 +39,14 @@ __license__ = "apache2"
 __email__ = 'amr.hassan@gmail.com'
 
 
-if sys.version_info[0] == 3:
+if sys.version_info.major == 3:
     import html.entities as htmlentitydefs
     from http.client import HTTPSConnection
     from urllib.parse import quote_plus as url_quote_plus
 
     unichr = chr
 
-elif sys.version_info[0] == 2:
+elif sys.version_info.major == 2:
     import htmlentitydefs
     from httplib import HTTPSConnection
     from urllib import quote_plus as url_quote_plus
@@ -2608,7 +2608,7 @@ def _string(string):
     if isinstance(string, str):
         return string
     casted = six.text_type(string)
-    if sys.version_info[0] == 2:
+    if sys.version_info.major == 2:
         casted = casted.encode("utf-8")
     return casted
 


### PR DESCRIPTION
For readability. 
New in Python 2.7+. 
https://docs.python.org/2/library/sys.html#sys.version_info

And treat only Python 2 as the special case, not Python 3.
For Python 4 compatibility.
https://astrofrog.github.io/blog/2016/01/12/stop-writing-python-4-incompatible-code/