### PR TITLE
Add missing limit parameter for track.getSimilar

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2016,13 +2016,17 @@ class Track(_Opus):
 
         self._request(self.ws_prefix + '.unlove')
 
-    def get_similar(self):
+    def get_similar(self, limit=None):
         """
         Returns similar tracks for this track on the network,
         based on listening data.
         """
 
-        doc = self._request(self.ws_prefix + '.getSimilar', True)
+        params = self._get_params()
+        if limit:
+            params['limit'] = limit
+
+        doc = self._request(self.ws_prefix + '.getSimilar', True, params)
 
         seq = []
         for node in doc.getElementsByTagName(self.ws_prefix):

--- a/tests/test_pylast_track.py
+++ b/tests/test_pylast_track.py
@@ -160,6 +160,16 @@ class TestPyLastTrack(PyLastTestCase):
                 break
         self.assertTrue(found)
 
+    def test_track_get_similar_limits(self):
+        # Arrange
+        track = pylast.Track("Cher", "Believe", self.network)
+
+        # Act/Assert
+        self.assertEqual(len(track.get_similar(limit=20)), 20)
+        self.assertLessEqual(len(track.get_similar(limit=10)), 10)
+        self.assertGreaterEqual(len(track.get_similar(limit=None)), 23)
+        self.assertGreaterEqual(len(track.get_similar(limit=0)), 23)
+
 
 if __name__ == '__main__':
     unittest.main(failfast=True)


### PR DESCRIPTION
Fixes #249 

Changes proposed in this pull request:

 * Add the limit parameter to the track.getSimilar query
