### PR TITLE
Fix user.get_weekly_artist_charts

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1169,8 +1169,15 @@ class _Chartable(object):
 
         seq = []
         for node in doc.getElementsByTagName(chart_kind.lower()):
-            item = chart_type(
-                _extract(node, "artist"), _extract(node, "name"), self.network)
+            if chart_kind == "artist":
+                item = chart_type(
+                    _extract(node, "name"),
+                    self.network)
+            else:
+                item = chart_type(
+                    _extract(node, "artist"),
+                    _extract(node, "name"),
+                    self.network)
             weight = _number(_extract(node, "playcount"))
             seq.append(TopItem(item, weight))
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -388,9 +388,10 @@ class TestPyLastUser(PyLastTestCase):
         # Arrange
         user = self.network.get_user("RJ")
 
-        # Act / Assert
+        # Act
         image = user.get_image()
 
+        # Assert
         self.assertTrue(image.startswith("https://"))
         self.assertTrue(image.endswith(".png"))
 
@@ -398,10 +399,35 @@ class TestPyLastUser(PyLastTestCase):
         # Arrange
         user = self.network.get_user("RJ")
 
-        # Act / Assert
+        # Act
         url = user.get_url()
 
+        # Assert
         self.assertEqual(url, "https://www.last.fm/user/rj")
+
+    def test_get_weekly_artist_charts(self):
+        # Arrange
+        user = self.network.get_user("bbc6music")
+
+        # Act
+        charts = user.get_weekly_artist_charts()
+        artist, weight = charts[0]
+
+        # Assert
+        self.assertIsNotNone(artist)
+        self.assertIsInstance(artist.network, pylast.LastFMNetwork)
+
+    def test_get_weekly_track_charts(self):
+        # Arrange
+        user = self.network.get_user("bbc6music")
+
+        # Act
+        charts = user.get_weekly_track_charts()
+        track, weight = charts[0]
+
+        # Assert
+        self.assertIsNotNone(track)
+        self.assertIsInstance(track.network, pylast.LastFMNetwork)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #257.

Changes proposed in this pull request:

 * When building the charts from the response from Last.fm, it was using some common code for charts for artists, albums and tracks.
 * It was creating artist, album or track objects by passing it the `artist` and `name` (and network).
 * But that only makes sense for album and track. For artists, there is no `artist` field, the `name` is the artist's name.