### PR TITLE
Use Markdown on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 from setuptools import find_packages, setup
 
+with open("README.md") as f:
+    long_description = f.read()
 
 setup(
     name="pylast",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     version="2.2.0.dev0",
     author="Amr Hassan <amr.hassan@gmail.com> and Contributors",
     install_requires=['six'],


### PR DESCRIPTION
Fixes #256.

Changes proposed in this pull request:

* Use README.md as the `long_description` on PyPI
* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example
