### PR TITLE
Close HTTPSConnection in case of exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,9 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -857,8 +857,10 @@ class _Request(object):
         except Exception as e:
             raise MalformedResponseError(self.network, e)
 
-        self._check_response_for_errors(response_text)
-        conn.close()
+        try:
+            self._check_response_for_errors(response_text)
+        finally:
+            conn.close()
         return response_text
 
     def execute(self, cacheable=False):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    once::DeprecationWarning
+    once::PendingDeprecationWarning


### PR DESCRIPTION
## Before:
```console
$ pytest -Wd -k test_init_with_token
================================================================= test session starts ==================================================================
platform darwin -- Python 3.6.4, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
Using --randomly-seed=1523434571
rootdir: /Users/hugo/github/pylast, inifile:
plugins: xdist-1.20.1, rerunfailures-3.1, randomly-1.2.3, forked-0.2, expect-1.1.0, cov-2.5.1, flaky-3.4.0
collected 130 items / 129 deselected

tests/test_network.py .                                                                                                                          [100%]
===Flaky Test Report===

test_init_with_token passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

=================================================================== warnings summary ===================================================================
tests/test_network.py::TestPyLastNetwork::test_init_with_token
  /Users/hugo/github/pylast/tests/test_network.py:286: ResourceWarning: unclosed <ssl.SSLSocket fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('172.27.89.164', 64150), raddr=('64.30.224.206', 443)>
    msg = str(exc)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
================================================= 1 passed, 129 deselected, 1 warnings in 1.97 seconds =================================================
```
## After:

```console
$ pytest -Wd -k test_init_with_token
================================================================= test session starts ==================================================================
platform darwin -- Python 3.6.4, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
Using --randomly-seed=1523434611
rootdir: /Users/hugo/github/pylast, inifile: pytest.ini
plugins: xdist-1.20.1, rerunfailures-3.1, randomly-1.2.3, forked-0.2, expect-1.1.0, cov-2.5.1, flaky-3.4.0
collected 130 items / 129 deselected

tests/test_network.py .                                                                                                                          [100%]
===Flaky Test Report===

test_init_with_token passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

======================================================= 1 passed, 129 deselected in 1.78 seconds =======================================================
```

Changes proposed in this pull request:

 * pytest shows warnings, but not `DeprecationWarning's by default. Show them.
 * Remove `ResourceWarning`: Close HTTPSConnection in case of exception
 * Ignore new pytest cache directory
