### PR TITLE
add images url to album class on get next page

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -1369,7 +1369,7 @@ class _Opus(_BaseObject, _Taggable):
 
     __hash__ = _BaseObject.__hash__
 
-    def __init__(self, artist, title, network, ws_prefix, username=None):
+    def __init__(self, artist, title, network, ws_prefix, username=None, images=None):
         """
         Create an opus instance.
         # Parameters:
@@ -1388,6 +1388,7 @@ class _Opus(_BaseObject, _Taggable):
 
         self.title = title
         self.username = username
+        self.images = images
 
     def __repr__(self):
         return "pylast.%s(%s, %s, %s)" % (
@@ -1485,8 +1486,8 @@ class Album(_Opus):
 
     __hash__ = _Opus.__hash__
 
-    def __init__(self, artist, title, network, username=None):
-        super(Album, self).__init__(artist, title, network, "album", username)
+    def __init__(self, artist, title, network, username=None, images=None):
+        super(Album, self).__init__(artist, title, network, "album", username, images)
 
     def get_cover_image(self, size=SIZE_EXTRA_LARGE):
         """
@@ -1497,10 +1498,12 @@ class Album(_Opus):
             SIZE_MEDIUM
             SIZE_SMALL
         """
-
-        return _extract_all(
-            self._request(
-                self.ws_prefix + ".getInfo", cacheable=True), 'image')[size]
+        if not self.images:
+            return _extract_all(
+                self._request(
+                    self.ws_prefix + ".getInfo", cacheable=True), 'image')[size]
+        else:
+            return self.images[size]
 
     def get_tracks(self):
         """Returns the list of Tracks on this album."""
@@ -2544,7 +2547,8 @@ class AlbumSearch(_Search):
             seq.append(Album(
                 _extract(node, "artist"),
                 _extract(node, "name"),
-                self.network))
+                self.network,
+                images=_extract_all(node, 'image')))
 
         return seq
 


### PR DESCRIPTION
Proof of concept #261 
Changes proposed in this pull request:

 * Add the images urls to the Album instance when its created by `network.album_search(query).get_next_page()` to avoid needing to make another request, all the necesary information is already supplied  in the request made by` get_next_page()`

this is a quick fix and only for albums the same can be done for artists and other information