### PR TITLE
'Tracks' with only one <name> are artists not tracks, skip them

### DIFF
--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2202,8 +2202,11 @@ class User(_BaseObject, _Chartable):
                 self.ws_prefix + ".getLovedTracks",
                 cacheable,
                 params):
+            try:
+                artist = _extract(track, "name", 1)
+            except IndexError:
+                continue
             title = _extract(track, "name")
-            artist = _extract(track, "name", 1)
             date = _extract(track, "date")
             timestamp = track.getElementsByTagName(
                 "date")[0].getAttribute("uts")

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2204,7 +2204,7 @@ class User(_BaseObject, _Chartable):
                 params):
             try:
                 artist = _extract(track, "name", 1)
-            except IndexError:
+            except IndexError:  # pragma: no cover
                 continue
             title = _extract(track, "name")
             date = _extract(track, "date")


### PR DESCRIPTION
Fixes #266.

Changes proposed in this pull request:

 * In one case, a list of loved tracks includes one `<track>` that looks like an artist
 * It has a single `<name>` for the `<artist>`, but none for the `<track>`
 * If this happens, skip it
