### PR TITLE
Single-source the package version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include pylast/__init__.py
+include pylast/*.py
 include setup.py
 include README.md
 include COPYING

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,10 @@
 # Release Checklist
 
 * [ ] Get master to the appropriate code release state. [Travis CI](https://travis-ci.org/pylast/pylast) should be running cleanly for all merges to master.
-* [ ] Remove `.dev0` suffix from version in `pylast/__init__.py` and `setup.py`:
+* [ ] Remove `.dev0` suffix from the version:
 ```bash
 git checkout master
-edit pylast/__init__.py setup.py
+edit pylast/version.py
 ```
 * [ ] Commit and tag with the version number:
 ```bash
@@ -28,10 +28,10 @@ git push --tags
 * [ ] Create new GitHub release: https://github.com/pylast/pylast/releases/new
   * Tag: Pick existing tag "2.1.0"
   * Title: "Release 2.1.0"
-* [ ] Increment version and append `.dev0` in `pylast/__init__.py` and `setup.py`:
+* [ ] Increment version and append `.dev0`:
 ```bash
 git checkout master
-edit pylast/__init__.py setup.py
+edit pylast/version.py
 ```
 * [ ] Commit and push:
 ```bash

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -32,14 +32,15 @@ import tempfile
 import time
 import xml.dom
 
-__version__ = "2.4.0.dev0"
+from . import version
+
 __author__ = "Amr Hassan, hugovk, Mice Pápai"
 __copyright__ = (
     "Copyright (C) 2008-2010 Amr Hassan, 2013-2018 hugovk, " "2017 Mice Pápai"
 )
 __license__ = "apache2"
 __email__ = "amr.hassan@gmail.com"
-
+__version__ = version.__version__
 
 if sys.version_info.major == 2:
     import htmlentitydefs

--- a/pylast/version.py
+++ b/pylast/version.py
@@ -1,0 +1,2 @@
+# Master version for pylast
+__version__ = "2.4.0.dev0"

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,16 @@ from setuptools import find_packages, setup
 with open("README.md") as f:
     long_description = f.read()
 
+version_dict = {}
+with open("pylast/version.py") as f:
+    exec(f.read(), version_dict)
+    version = version_dict['__version__']
+
 setup(
     name="pylast",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.4.0.dev0",
+    version=version,
     author="Amr Hassan <amr.hassan@gmail.com> and Contributors",
     install_requires=["six"],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 version_dict = {}
 with open("pylast/version.py") as f:
     exec(f.read(), version_dict)
-    version = version_dict['__version__']
+    version = version_dict["__version__"]
 
 setup(
     name="pylast",

--- a/tox.ini
+++ b/tox.ini
@@ -44,4 +44,4 @@ deps =
     black
 commands =
     {[testenv:lint]commands}
-    black --check .
+    black --check --diff .


### PR DESCRIPTION
Changes proposed in this pull request:

 * Only include the version in one place
 * Makes releasing that little bit easier

https://packaging.python.org/guides/single-sourcing-package-version/