### PR TITLE
Revert PyYAML workaround for Python 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@ setenv =
     PYLAST_API_KEY={env:PYLAST_API_KEY:}
     PYLAST_API_SECRET={env:PYLAST_API_SECRET:}
 deps =
-    # Workaround for yaml/pyyaml#126
-    py27,py36,py35,py34,pypy,pypy3,py36dev: pyyaml
-    py37dev: git+https://github.com/yaml/pyyaml@master#egg=pyyaml
+    pyyaml
     pytest
     mock
     ipdb


### PR DESCRIPTION
PyYAML 4.1 has been released, supporting Python 3.7.
 
We can now revert workaround https://github.com/pylast/pylast/pull/255/commits/f2ec5bc57ef06c0f8db9a92f2ebb628460e358aa from PR https://github.com/pylast/pylast/pull/255.