### PR TITLE
Test on official Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
       env: TOXENV=py27
     - python: 3.6
       env: TOXENV=py3lint
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      sudo: true
     - python: 3.6
       env: TOXENV=py36
     - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py35, py34, pypy, pypy3, py36dev, py37dev
+envlist = py27, py37, py36, py35, py34, pypy, pypy3, py36dev, py37dev
 recreate = False
 
 [testenv]


### PR DESCRIPTION
Fixes #278.

Changes proposed in this pull request:

 * Add official Python 3.7 to CI
   * It requires Xenial and sudo: https://github.com/travis-ci/travis-ci/issues/9069

 * Keep `3.7-dev` and `3.6-dev` for now, even though they've not been updated for a while
     * `3.6-dev` is 3.6.5+, but 3.6.6 is the latest
     * `3.7-dev` is 3.7.0a4+, but 3.7.0 is the latest
     * Can remove them in the future if they don't update
