### PR TITLE
Drop support for legacy Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,8 @@ env:
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py2lint
-    - python: 2.7
-      env: TOXENV=py27
     - python: 3.6
-      env: TOXENV=py3lint
+      env: TOXENV=lint
     - python: 3.7
       env: TOXENV=py37
       dist: xenial
@@ -33,14 +29,11 @@ matrix:
       env: TOXENV=py34
     - python: pypy3
       env: TOXENV=pypy3
-    - python: pypy
-      env: TOXENV=pypy
     - python: 3.6-dev
       env: TOXENV=py36dev
     - python: 3.7-dev
       env: TOXENV=py37dev
   allow_failures:
-    - env: TOXENV=pypy
     - env: TOXENV=pypy3
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.5
       env: TOXENV=py35
-    - python: 3.4
-      env: TOXENV=py34
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.6-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - This changelog file ([#273])
 
+### Removed
+
+* Support for Python 2.7 ([#265])
 
 ## [2.4.0] - 2018-08-08
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Or from requirements.txt:
 
 Note:
 
-* pylast >= 3.0.0 will likely only support Python 3.4+ ([#265](https://github.com/pylast/pylast/issues/265))
-* pyLast >= 2.2.0 supports Python 2.7.10+, 3.4, 3.5, 3.6, 3.7.
-* pyLast >= 2.0.0 < 2.2.0 supports Python 2.7.10+, 3.4, 3.5, 3.6.
-* pyLast >= 1.7.0 < 2.0.0 supports Python 2.7, 3.3, 3.4, 3.5, 3.6.
-* pyLast >= 1.0.0 < 1.7.0 supports Python 2.7, 3.3, 3.4.
-* pyLast >= 0.5 < 1.0.0 supports Python 2, 3.
+* pylast 3.0.0+ supports Python 3.4+ ([#265](https://github.com/pylast/pylast/issues/265))
+* pyLast 2.2.0 - 2.4.0 supports Python 2.7.10+, 3.4, 3.5, 3.6, 3.7.
+* pyLast 2.0.0 - 2.1.0 supports Python 2.7.10+, 3.4, 3.5, 3.6.
+* pyLast 1.7.0 - 1.9.0 supports Python 2.7, 3.3, 3.4, 3.5, 3.6.
+* pyLast 1.0.0 - 1.6.0 supports Python 2.7, 3.3, 3.4.
+* pyLast 0.5 supports Python 2, 3.
 * pyLast < 0.5 supports Python 2.
 
 Features

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 Install via pip:
 
     pip install pylast
-    
+
 Install latest development version:
 
     pip install -U git+https://github.com/pylast/pylast.git
@@ -29,7 +29,7 @@ Or from requirements.txt:
 
 Note:
 
-* pylast 3.0.0+ supports Python 3.4+ ([#265](https://github.com/pylast/pylast/issues/265))
+* pylast 3.0.0+ supports Python 3.5+ ([#265](https://github.com/pylast/pylast/issues/265))
 * pyLast 2.2.0 - 2.4.0 supports Python 2.7.10+, 3.4, 3.5, 3.6, 3.7.
 * pyLast 2.0.0 - 2.1.0 supports Python 2.7.10+, 3.4, 3.5, 3.6.
 * pyLast 1.7.0 - 1.9.0 supports Python 2.7, 3.3, 3.4, 3.5, 3.6.

--- a/clonedigger.sh
+++ b/clonedigger.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-clonedigger pylast
-grep -E "Clones detected|lines are duplicates" output.html
-exit 0

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -139,7 +139,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
-class _Network(object):
+class _Network:
     """
     A music social network website such as Last.fm or
     one with a Last.fm-compatible API.
@@ -796,7 +796,7 @@ class LibreFMNetwork(_Network):
         )
 
 
-class _ShelfCacheBackend(object):
+class _ShelfCacheBackend:
     """Used as a backend for caching cacheable requests."""
 
     def __init__(self, file_path=None):
@@ -817,7 +817,7 @@ class _ShelfCacheBackend(object):
         self.shelf[key] = xml_string
 
 
-class _Request(object):
+class _Request:
     """Representing an abstract web service operation."""
 
     def __init__(self, network, method_name, params=None):
@@ -982,7 +982,7 @@ class _Request(object):
             raise WSError(self.network, status, details)
 
 
-class SessionKeyGenerator(object):
+class SessionKeyGenerator:
     """Methods of generating a session key:
     1) Web Authentication:
         a. network = get_*_network(API_KEY, API_SECRET)
@@ -1105,7 +1105,7 @@ def _string_output(func):
     return r
 
 
-class _BaseObject(object):
+class _BaseObject:
     """An abstract webservices object."""
 
     network = None
@@ -1194,7 +1194,7 @@ class _BaseObject(object):
         return _extract(node, section)
 
 
-class _Chartable(object):
+class _Chartable:
     """Common functions for classes with charts."""
 
     def __init__(self, ws_prefix):
@@ -1265,7 +1265,7 @@ class _Chartable(object):
         return seq
 
 
-class _Taggable(object):
+class _Taggable:
     """Common functions for classes with tags."""
 
     def __init__(self, ws_prefix):
@@ -1594,7 +1594,7 @@ class Album(_Opus):
     __hash__ = _Opus.__hash__
 
     def __init__(self, artist, title, network, username=None, info=None):
-        super(Album, self).__init__(artist, title, network, "album", username, info)
+        super().__init__(artist, title, network, "album", username, info)
 
     def get_tracks(self):
         """Returns the list of Tracks on this album."""
@@ -2063,7 +2063,7 @@ class Track(_Opus):
     __hash__ = _Opus.__hash__
 
     def __init__(self, artist, title, network, username=None, info=None):
-        super(Track, self).__init__(artist, title, network, "track", username, info)
+        super().__init__(artist, title, network, "track", username, info)
 
     def get_correction(self):
         """Returns the corrected track name."""

--- a/pylast/version.py
+++ b/pylast/version.py
@@ -1,2 +1,2 @@
 # Master version for pylast
-__version__ = "2.5.0.dev0"
+__version__ = "3.0.0.dev0"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("pylast/version.py") as f:
     version = version_dict["__version__"]
 
 
-if sys.version_info < (3, 4):
+if sys.version_info < (3, 5):
     error = """pylast 3.0 and above are no longer compatible with Python 2.
 
 This is pylast {} and you are using Python {}.
@@ -64,7 +64,6 @@ setup(
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -72,7 +71,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     keywords=["Last.fm", "music", "scrobble", "scrobbling"],
     packages=find_packages(exclude=("tests*",)),
     license="Apache2",

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,43 @@
 #!/usr/bin/env python
-from setuptools import find_packages, setup
+from __future__ import print_function
+import sys
 
-with open("README.md") as f:
-    long_description = f.read()
+from setuptools import find_packages, setup
 
 version_dict = {}
 with open("pylast/version.py") as f:
     exec(f.read(), version_dict)
     version = version_dict["__version__"]
+
+
+if sys.version_info < (3, 4):
+    error = """pylast 3.0 and above are no longer compatible with Python 2.
+
+This is pylast {} and you are using Python {}.
+Make sure you have pip >= 9.0 and setuptools >= 24.2 and retry:
+
+ $ pip install --upgrade pip setuptools
+
+Other choices:
+
+- Upgrade to Python 3.
+
+- Install an older version of pylast:
+
+$ pip install 'pylast<3.0'
+
+For more information:
+
+https://github.com/pylast/pylast/issues/265
+""".format(
+        version, ".".join([str(v) for v in sys.version_info[:3]])
+    )
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
+with open("README.md") as f:
+    long_description = f.read()
+
 
 setup(
     name="pylast",
@@ -15,7 +45,6 @@ setup(
     long_description_content_type="text/markdown",
     version=version,
     author="Amr Hassan <amr.hassan@gmail.com> and Contributors",
-    install_requires=["six"],
     tests_require=[
         "coverage",
         "flaky",
@@ -34,17 +63,16 @@ setup(
         "Topic :: Internet",
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    python_requires=">=2.7.10, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.4",
     keywords=["Last.fm", "music", "scrobble", "scrobbling"],
     packages=find_packages(exclude=("tests*",)),
     license="Apache2",

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -67,7 +67,7 @@ class TestPyLastUser(TestPyLastWithLastFm):
         else:
             # Old way
             # Just check date because of timezones
-            self.assertIn(u"2002-11-20 ", registered)
+            self.assertIn("2002-11-20 ", registered)
 
     def test_get_user_unixtime_registration(self):
         # Arrange

--- a/tests/unicode_test.py
+++ b/tests/unicode_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import mock
 import pytest
-import six
 
 import pylast
 
@@ -13,9 +12,9 @@ def mock_network():
 @pytest.mark.parametrize(
     "artist",
     [
-        u"\xe9lafdasfdsafdsa",
-        u"ééééééé",
-        pylast.Artist(u"B\xe9l", mock_network()),
+        "\xe9lafdasfdsafdsa",
+        "ééééééé",
+        pylast.Artist("B\xe9l", mock_network()),
         "fdasfdsafsaf not unicode",
     ],
 )
@@ -24,7 +23,7 @@ def test_get_cache_key(artist):
     request._get_cache_key()
 
 
-@pytest.mark.parametrize("obj", [pylast.Artist(u"B\xe9l", mock_network())])
+@pytest.mark.parametrize("obj", [pylast.Artist("B\xe9l", mock_network())])
 def test_cast_and_hash(obj):
-    assert type(six.text_type(obj)) is six.text_type
+    assert type(str(obj)) is str
     assert isinstance(hash(obj), int)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py36, py35, py34, pypy3, py36dev, py37dev
+envlist = py37, py36, py35, pypy3, py36dev, py37dev
 recreate = False
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py37, py36, py35, py34, pypy, pypy3, py36dev, py37dev
+envlist = py37, py36, py35, py34, pypy3, py36dev, py37dev
 recreate = False
 
 [testenv]
@@ -25,21 +25,7 @@ commands = {posargs}
 deps =
     flake8
     pep8-naming
-commands =
-    flake8 .
-
-[testenv:py2lint]
-deps =
-    {[testenv:lint]deps}
-    clonedigger
-commands =
-    {[testenv:lint]commands}
-    ./clonedigger.sh
-
-[testenv:py3lint]
-deps =
-    {[testenv:lint]deps}
     black
 commands =
-    {[testenv:lint]commands}
+    flake8 .
     black --check --diff .


### PR DESCRIPTION
Changes proposed in this pull request:

* It's not long until Python 3.4's EOL on 2019-03-16
* Python 3.4 isn't used much
* A backwards-incompatible release is coming up soon (dropping Python 2 https://github.com/pylast/pylast/pull/281) so  it's a good time to bundle this into a major version release
* Upgrade Python syntax with ``pyupgrade `find . -name "*.py"` --py3-plus``
* Includes PR https://github.com/pylast/pylast/pull/281 to avoid merge conflicts

Here's the pip installs for pylast from PyPI for last month:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  41.59% |     2,123 |
|      3.6 |  36.85% |     1,881 |
|      3.5 |   8.85% |       452 |
| null     |   5.99% |       306 |
|      3.7 |   5.80% |       296 |
|      3.4 |   0.82% |        42 |
|      3.3 |   0.10% |         5 |
| Total    |         |     5,105 |

Source: `pypistats python_minor --last-month pylast`

![image](https://user-images.githubusercontent.com/1324225/49042531-13f3be00-f1d1-11e8-902e-81854bb90a2a.png)

https://github.com/hugovk/pypi-tools#examples
