### PR TITLE
CI: Test on 3.8-dev, remove 3.6-dev and 3.7-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
       env: TOXENV=pypy
     - python: 3.8-dev
       env: TOXENV=py38dev
+      dist: xenial
   allow_failures:
     - env: TOXENV=pypy
     - env: TOXENV=pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,8 @@ matrix:
       env: TOXENV=pypy3
     - python: pypy
       env: TOXENV=pypy
-    - python: 3.6-dev
-      env: TOXENV=py36dev
-    - python: 3.7-dev
-      env: TOXENV=py37dev
+    - python: 3.8-dev
+      env: TOXENV=py38dev
   allow_failures:
     - env: TOXENV=pypy
     - env: TOXENV=pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py37, py36, py35, py34, pypy, pypy3, py36dev, py37dev
+envlist = py27, py37, py36, py35, py34, pypy, pypy3, py38dev
 recreate = False
 
 [testenv]


### PR DESCRIPTION
Fixes #286. 

Changes proposed in this pull request:

 * Add 3.8-dev
 * Remove 3.7-dev
 * Remove 3.6-dev

There's been no change since https://github.com/pylast/pylast/pull/279, July 2018:

* `3.6-dev` is 3.6.5+, but 3.6.7 is the latest
* `3.7-dev` is 3.7.0a4+, but 3.7.1 is the latest
