### PR TITLE
Drop support for legacy Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.5
       env: TOXENV=py35
-    - python: 3.4
-      env: TOXENV=py34
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.8-dev

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 Install via pip:
 
     pip install pylast
-    
+
 Install latest development version:
 
     pip install -U git+https://github.com/pylast/pylast.git
@@ -29,7 +29,7 @@ Or from requirements.txt:
 
 Note:
 
-* pylast 3.0.0+ supports Python 3.4+ ([#265](https://github.com/pylast/pylast/issues/265))
+* pylast 3.0.0+ supports Python 3.5+ ([#265](https://github.com/pylast/pylast/issues/265))
 * pyLast 2.2.0 - 2.4.0 supports Python 2.7.10+, 3.4, 3.5, 3.6, 3.7.
 * pyLast 2.0.0 - 2.1.0 supports Python 2.7.10+, 3.4, 3.5, 3.6.
 * pyLast 1.7.0 - 1.9.0 supports Python 2.7, 3.3, 3.4, 3.5, 3.6.

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -138,7 +138,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
-class _Network(object):
+class _Network:
     """
     A music social network website such as Last.fm or
     one with a Last.fm-compatible API.
@@ -795,7 +795,7 @@ class LibreFMNetwork(_Network):
         )
 
 
-class _ShelfCacheBackend(object):
+class _ShelfCacheBackend:
     """Used as a backend for caching cacheable requests."""
 
     def __init__(self, file_path=None):
@@ -816,7 +816,7 @@ class _ShelfCacheBackend(object):
         self.shelf[key] = xml_string
 
 
-class _Request(object):
+class _Request:
     """Representing an abstract web service operation."""
 
     def __init__(self, network, method_name, params=None):
@@ -981,7 +981,7 @@ class _Request(object):
             raise WSError(self.network, status, details)
 
 
-class SessionKeyGenerator(object):
+class SessionKeyGenerator:
     """Methods of generating a session key:
     1) Web Authentication:
         a. network = get_*_network(API_KEY, API_SECRET)
@@ -1104,7 +1104,7 @@ def _string_output(func):
     return r
 
 
-class _BaseObject(object):
+class _BaseObject:
     """An abstract webservices object."""
 
     network = None
@@ -1193,7 +1193,7 @@ class _BaseObject(object):
         return _extract(node, section)
 
 
-class _Chartable(object):
+class _Chartable:
     """Common functions for classes with charts."""
 
     def __init__(self, ws_prefix):
@@ -1264,7 +1264,7 @@ class _Chartable(object):
         return seq
 
 
-class _Taggable(object):
+class _Taggable:
     """Common functions for classes with tags."""
 
     def __init__(self, ws_prefix):
@@ -1593,7 +1593,7 @@ class Album(_Opus):
     __hash__ = _Opus.__hash__
 
     def __init__(self, artist, title, network, username=None, info=None):
-        super(Album, self).__init__(artist, title, network, "album", username, info)
+        super().__init__(artist, title, network, "album", username, info)
 
     def get_tracks(self):
         """Returns the list of Tracks on this album."""
@@ -2062,7 +2062,7 @@ class Track(_Opus):
     __hash__ = _Opus.__hash__
 
     def __init__(self, artist, title, network, username=None, info=None):
-        super(Track, self).__init__(artist, title, network, "track", username, info)
+        super().__init__(artist, title, network, "track", username, info)
 
     def get_correction(self):
         """Returns the corrected track name."""

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("pylast/version.py") as f:
     version = version_dict["__version__"]
 
 
-if sys.version_info < (3, 4):
+if sys.version_info < (3, 5):
     error = """pylast 3.0 and above are no longer compatible with Python 2.
 
 This is pylast {} and you are using Python {}.
@@ -64,7 +64,6 @@ setup(
         "Topic :: Multimedia :: Sound/Audio",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -72,7 +71,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     keywords=["Last.fm", "music", "scrobble", "scrobbling"],
     packages=find_packages(exclude=("tests*",)),
     license="Apache2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py36, py35, py34, pypy3, py38dev
+envlist = py37, py36, py35, pypy3, py38dev
 recreate = False
 
 [testenv]


### PR DESCRIPTION
Changes proposed in this pull request:

* It's not long until Python 3.4's EOL on 2019-03-16
* Python 3.4 isn't used much
* A backwards-incompatible release is coming up soon (dropping Python 2 https://github.com/pylast/pylast/pull/281) so  it's a good time to bundle this into a major version release
* Upgrade Python syntax with ``pyupgrade `find . -name "*.py"` --py3-plus``
* Includes PR https://github.com/pylast/pylast/pull/281 to avoid merge conflicts

Here's the pip installs for pylast from PyPI for last month:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  41.59% |     2,123 |
|      3.6 |  36.85% |     1,881 |
|      3.5 |   8.85% |       452 |
| null     |   5.99% |       306 |
|      3.7 |   5.80% |       296 |
|      3.4 |   0.82% |        42 |
|      3.3 |   0.10% |         5 |
| Total    |         |     5,105 |

Source: `pypistats python_minor --last-month pylast`

![image](https://user-images.githubusercontent.com/1324225/49042531-13f3be00-f1d1-11e8-902e-81854bb90a2a.png)

https://github.com/hugovk/pypi-tools#examples
