### PR TITLE
Fix the build

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -26,6 +26,7 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
         self.network.scrobble(artist=artist, title=title, timestamp=timestamp)
 
         # Assert
+        time.sleep(1)  # Delay, for Last.fm latency. TODO Can this be removed later?
         # limit=2 to ignore now-playing:
         last_scrobble = lastfm_user.get_recent_tracks(limit=2)[0]
         self.assertEqual(str(last_scrobble.track.artist).lower(), artist)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2,6 +2,7 @@
 """
 Integration (not unit) tests for pylast.py
 """
+import sys
 import time
 import unittest
 
@@ -11,6 +12,9 @@ from .test_pylast import TestPyLastWithLastFm
 
 
 class TestPyLastNetwork(TestPyLastWithLastFm):
+    @unittest.skipUnless(
+        sys.version_info[:2] == (3, 7), "Only run on Python 3.7 to avoid collisions"
+    )
     def test_scrobble(self):
         # Arrange
         artist = "test artist"

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2,19 +2,16 @@
 """
 Integration (not unit) tests for pylast.py
 """
-import sys
 import time
 import unittest
 
 import pylast
 
-from .test_pylast import TestPyLastWithLastFm
+from .test_pylast import PY37, TestPyLastWithLastFm
 
 
 class TestPyLastNetwork(TestPyLastWithLastFm):
-    @unittest.skipUnless(
-        sys.version_info[:2] == (3, 7), "Only run on Python 3.7 to avoid collisions"
-    )
+    @unittest.skipUnless(PY37, "Only run on Python 3.7 to avoid collisions")
     def test_scrobble(self):
         # Arrange
         artist = "test artist"
@@ -24,9 +21,9 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
 
         # Act
         self.network.scrobble(artist=artist, title=title, timestamp=timestamp)
+        time.sleep(1)  # Delay, for Last.fm latency. TODO Can this be removed later?
 
         # Assert
-        time.sleep(1)  # Delay, for Last.fm latency. TODO Can this be removed later?
         # limit=2 to ignore now-playing:
         last_scrobble = lastfm_user.get_recent_tracks(limit=2)[0]
         self.assertEqual(str(last_scrobble.track.artist).lower(), artist)

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -3,6 +3,7 @@
 Integration (not unit) tests for pylast.py
 """
 import os
+import sys
 import time
 import unittest
 
@@ -10,6 +11,9 @@ import pytest
 from flaky import flaky
 
 import pylast
+
+
+PY37 = sys.version_info[:2] == (3, 7)
 
 
 def load_secrets():

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -6,10 +6,11 @@ import unittest
 
 import pylast
 
-from .test_pylast import TestPyLastWithLastFm
+from .test_pylast import PY37, TestPyLastWithLastFm
 
 
 class TestPyLastTrack(TestPyLastWithLastFm):
+    @unittest.skipUnless(PY37, "Only run on Python 3.7 to avoid collisions")
     def test_love(self):
         # Arrange
         artist = "Test Artist"

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pytest-cov
     pytest-random-order
     flaky
-commands = pytest -v -s -W all --cov pylast --cov-report term-missing {posargs}
+commands = pytest -v -s -W all --cov pylast --cov-report term-missing --random-order {posargs}
 
 [testenv:venv]
 deps = ipdb

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     mock
     ipdb
     pytest-cov
+    pytest-random-order
     flaky
 commands = pytest -v -s -W all --cov pylast --cov-report term-missing {posargs}
 


### PR DESCRIPTION
Some tests (`test_scrobble`, `test_unlove`) were sometimes failing, as the write API action they'd just made wasn't showing in the read API assert. 

This could be due:

* to parallel build jobs running the same test at the same time mitigated by running tests in a random order, and only running on a single Python version
* there may a small delay in Last.fm updating the write before returning the read, mitigated by a `time.sleep(1)`
