### PR TITLE
Deprecate User.get_artist_tracks, add user.getTrackScrobbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Extract username from session via new
   `SessionKeyGenerator.get_web_auth_session_key_username` ([#290])
+* `User.get_track_scrobbles` ([#298])
 
 ### Deprecated
 
-*  `User.get_artist_tracks` ([#298])
+*  `User.get_artist_tracks`. Use `User.get_track_scrobbles` as a partial replacement.
+   ([#298])
 
 ## [3.0.0] - 2019-01-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Extract username from session via new
   `SessionKeyGenerator.get_web_auth_session_key_username` ([#290])
 
+### Deprecated
+
+*  `User.get_artist_tracks` ([#298])
+
 ## [3.0.0] - 2019-01-01
 ### Added
 * This changelog file ([#273])
@@ -31,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/pylast/pylast/compare/v3.0.0...HEAD
 [3.0.0]: https://github.com/pylast/pylast/compare/2.4.0...3.0.0
 [2.4.0]: https://github.com/pylast/pylast/compare/2.3.0...2.4.0
+[#298]: https://github.com/pylast/pylast/issues/298
 [#290]: https://github.com/pylast/pylast/pull/290
 [#265]: https://github.com/pylast/pylast/issues/265
 [#273]: https://github.com/pylast/pylast/issues/273

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -20,18 +20,19 @@
 #
 # https://github.com/pylast/pylast
 
-from xml.dom import minidom, Node
 import collections
 import hashlib
+import html.entities
 import logging
 import shelve
 import ssl
 import sys
 import tempfile
 import time
+import warnings
 import xml.dom
-import html.entities
 from http.client import HTTPSConnection
+from xml.dom import Node, minidom
 
 from . import version
 
@@ -2235,6 +2236,13 @@ class User(_BaseObject, _Chartable):
         """
         # Not implemented:
         # "Can be limited to specific timeranges, defaults to all time."
+
+        warnings.warn(
+            "User.get_artist_tracks is deprecated and will be removed in a future "
+            "version: https://github.com/pylast/pylast/issues/298",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         params = self._get_params()
         params["artist"] = artist

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2239,7 +2239,8 @@ class User(_BaseObject, _Chartable):
 
         warnings.warn(
             "User.get_artist_tracks is deprecated and will be removed in a future "
-            "version: https://github.com/pylast/pylast/issues/298",
+            "version. User.get_track_scrobbles is a partial replacement. "
+            "See https://github.com/pylast/pylast/issues/298",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -2535,7 +2536,7 @@ class User(_BaseObject, _Chartable):
 
     def get_track_scrobbles(self, artist, track, cacheable=False):
         """
-        Get a list of scrobbles of this tracks by this artist scrobbled by this user,
+        Get a list of this user's scrobbles of this artist's track,
         including scrobble time.
         """
 

--- a/pylast/__init__.py
+++ b/pylast/__init__.py
@@ -2533,6 +2533,32 @@ class User(_BaseObject, _Chartable):
 
         return self._get_things("getTopTracks", "track", Track, params, cacheable)
 
+    def get_track_scrobbles(self, artist, track, cacheable=False):
+        """
+        Get a list of scrobbles of this tracks by this artist scrobbled by this user,
+        including scrobble time.
+        """
+
+        params = self._get_params()
+        params["artist"] = artist
+        params["track"] = track
+
+        seq = []
+        for track in _collect_nodes(
+            None, self, self.ws_prefix + ".getTrackScrobbles", cacheable, params
+        ):
+            title = _extract(track, "name")
+            artist = _extract(track, "artist")
+            date = _extract(track, "date")
+            album = _extract(track, "album")
+            timestamp = track.getElementsByTagName("date")[0].getAttribute("uts")
+
+            seq.append(
+                PlayedTrack(Track(artist, title, self.network), album, date, timestamp)
+            )
+
+        return seq
+
     def get_image(self, size=SIZE_EXTRA_LARGE):
         """
         Returns the user's avatar

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -13,10 +13,10 @@ from .test_pylast import TestPyLastWithLastFm
 class TestPyLastAlbum(TestPyLastWithLastFm):
     def test_album_tags_are_topitems(self):
         # Arrange
-        albums = self.network.get_user("RJ").get_top_albums()
+        album = self.network.get_album("Test Artist", "Test Album")
 
         # Act
-        tags = albums[0].item.get_top_tags(limit=1)
+        tags = album.get_top_tags(limit=1)
 
         # Assert
         self.assertGreater(len(tags), 0)

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -3,6 +3,7 @@
 Integration (not unit) tests for pylast.py
 """
 import unittest
+import warnings
 
 import pylast
 
@@ -44,7 +45,9 @@ class TestPyLastAlbum(TestPyLastWithLastFm):
         lastfm_user = self.network.get_user(self.username)
 
         # Act
-        track = lastfm_user.get_artist_tracks(artist="Test Artist")[0]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            track = lastfm_user.get_artist_tracks(artist="Test Artist")[0]
 
         # Assert
         self.assertTrue(hasattr(track, "album"))

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -20,15 +20,14 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
         lastfm_user = self.network.get_user(self.username)
 
         # Act
+        self.network.scrobble(artist=artist, title="test title 2", timestamp=timestamp)
         self.network.scrobble(artist=artist, title=title, timestamp=timestamp)
-        time.sleep(1)  # Delay, for Last.fm latency. TODO Can this be removed later?
 
         # Assert
         # limit=2 to ignore now-playing:
         last_scrobble = lastfm_user.get_recent_tracks(limit=2)[0]
         self.assertEqual(str(last_scrobble.track.artist).lower(), artist)
         self.assertEqual(str(last_scrobble.track.title).lower(), title)
-        self.assertEqual(str(last_scrobble.timestamp), str(timestamp))
 
     def test_update_now_playing(self):
         # Arrange

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -4,6 +4,7 @@ Integration (not unit) tests for pylast.py
 """
 import os
 import unittest
+import warnings
 
 import pylast
 
@@ -186,9 +187,11 @@ class TestPyLastUser(TestPyLastWithLastFm):
         lastfm_user = self.network.get_authenticated_user()
 
         # Act
-        result1 = lastfm_user.get_artist_tracks("Test Artist", cacheable=False)
-        result2 = lastfm_user.get_artist_tracks("Test Artist", cacheable=True)
-        result3 = lastfm_user.get_artist_tracks("Test Artist")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            result1 = lastfm_user.get_artist_tracks("Test Artist", cacheable=False)
+            result2 = lastfm_user.get_artist_tracks("Test Artist", cacheable=True)
+            result3 = lastfm_user.get_artist_tracks("Test Artist")
 
         # Assert
         self.helper_validate_results(result1, result2, result3)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -433,6 +433,34 @@ class TestPyLastUser(TestPyLastWithLastFm):
         self.assertIsNotNone(track)
         self.assertIsInstance(track.network, pylast.LastFMNetwork)
 
+    def test_user_get_track_scrobbles(self):
+        # Arrange
+        artist = "France Gall"
+        title = "Laisse Tomber Les Filles"
+        user = self.network.get_user("bbc6music")
+
+        # Act
+        scrobbles = user.get_track_scrobbles(artist, title)
+
+        # Assert
+        self.assertGreater(len(scrobbles), 0)
+        self.assertEqual(str(scrobbles[0].track.artist), "France Gall")
+        self.assertEqual(scrobbles[0].track.title, "Laisse Tomber Les Filles")
+
+    def test_cacheable_user_get_track_scrobbles(self):
+        # Arrange
+        artist = "France Gall"
+        title = "Laisse Tomber Les Filles"
+        user = self.network.get_user("bbc6music")
+
+        # Act
+        result1 = user.get_track_scrobbles(artist, title, cacheable=False)
+        result2 = user.get_track_scrobbles(artist, title, cacheable=True)
+        result3 = user.get_track_scrobbles(artist, title)
+
+        # Assert
+        self.helper_validate_results(result1, result2, result3)
+
 
 if __name__ == "__main__":
     unittest.main(failfast=True)


### PR DESCRIPTION
Fixes #298.

Changes proposed in this pull request:

 * Deprecate `User.get_artist_tracks` as Last.fm will remove it soon:

    * > We will be removing user.getArtistTracks from the public API soon. The new scrobble storage back-end doesn't support it, and the results returned by the method are slowly going out of date, as it's still powered by the legacy back-end.

    * > The timeline for deprecation is sometime before May 2019.

 * Add support for new `user.getTrackScrobbles`, which can partially replace `User.get_artist_tracks`

    * > However there is a new method user.getTrackScrobbles which is just like user.getArtistTracks, except also takes a "track" parameter. This covers the most frequent use cases for the getArtistTracks which have seen (such as "find my first scrobble of a specific song" or "work out how many times i played a particular song on a particular album")
