### PR TITLE
Remove deprecated license_file from setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ pyLast
 [![Build status](https://travis-ci.org/pylast/pylast.svg?branch=master)](https://travis-ci.org/pylast/pylast)
 [![Coverage (Codecov)](https://codecov.io/gh/pylast/pylast/branch/master/graph/badge.svg)](https://codecov.io/gh/pylast/pylast)
 [![Coverage (Coveralls)](https://coveralls.io/repos/github/pylast/pylast/badge.svg?branch=master)](https://coveralls.io/github/pylast/pylast?branch=master)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/black/black)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 A Python interface to [Last.fm](https://www.last.fm/) and other API-compatible websites such as [Libre.fm](https://libre.fm/).
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,5 @@ universal = 1
 ignore = W503
 max_line_length = 88
 
-[metadata]
-license_file = COPYING
-
 [pycodestyle]
 max_line_length = 88

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -5,6 +5,8 @@ Integration (not unit) tests for pylast.py
 import unittest
 import warnings
 
+import pytest
+
 import pylast
 
 from .test_pylast import TestPyLastWithLastFm
@@ -40,6 +42,7 @@ class TestPyLastAlbum(TestPyLastWithLastFm):
         # Assert
         self.assertTrue(hasattr(track, "album"))
 
+    @pytest.mark.skip(reason="Last.fm is removing from API")
     def test_album_in_artist_tracks(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)


### PR DESCRIPTION
Starting with wheel 0.32.0 (2018-09-29), the "license_file" option is deprecated.

https://wheel.readthedocs.io/en/stable/news.html

The wheel will continue to include COPYING, it is now included automatically:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

---

Also update a badge link.
