### PR TITLE
Update user.get_artist_tracks tests

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2260,11 +2260,10 @@ class User(_BaseObject, _Chartable):
 
     def get_artist_tracks(self, artist, cacheable=False):
         """
+        Deprecated by Last.fm.
         Get a list of tracks by a given artist scrobbled by this user,
         including scrobble time.
         """
-        # Not implemented:
-        # "Can be limited to specific timeranges, defaults to all time."
 
         warnings.warn(
             "User.get_artist_tracks is deprecated and will be removed in a future "

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -3,9 +3,6 @@
 Integration (not unit) tests for pylast.py
 """
 import unittest
-import warnings
-
-import pytest
 
 import pylast
 
@@ -38,19 +35,6 @@ class TestPyLastAlbum(TestPyLastWithLastFm):
         # Act
         # limit=2 to ignore now-playing:
         track = lastfm_user.get_recent_tracks(limit=2)[0]
-
-        # Assert
-        self.assertTrue(hasattr(track, "album"))
-
-    @pytest.mark.skip(reason="Last.fm is removing from API")
-    def test_album_in_artist_tracks(self):
-        # Arrange
-        lastfm_user = self.network.get_user(self.username)
-
-        # Act
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            track = lastfm_user.get_artist_tracks(artist="Test Artist")[0]
 
         # Assert
         self.assertTrue(hasattr(track, "album"))

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -182,20 +182,6 @@ class TestPyLastUser(TestPyLastWithLastFm):
         # Assert
         self.assertEqual(lastfm_user, loaded_user)
 
-    def test_cacheable_user_artist_tracks(self):
-        # Arrange
-        lastfm_user = self.network.get_authenticated_user()
-
-        # Act
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            result1 = lastfm_user.get_artist_tracks("Test Artist", cacheable=False)
-            result2 = lastfm_user.get_artist_tracks("Test Artist", cacheable=True)
-            result3 = lastfm_user.get_artist_tracks("Test Artist")
-
-        # Assert
-        self.helper_validate_results(result1, result2, result3)
-
     def test_cacheable_user(self):
         # Arrange
         lastfm_user = self.network.get_authenticated_user()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -461,6 +461,17 @@ class TestPyLastUser(TestPyLastWithLastFm):
         # Assert
         self.helper_validate_results(result1, result2, result3)
 
+    def test_get_artist_tracks_deprecated(self):
+        # Arrange
+        lastfm_user = self.network.get_user(self.username)
+
+        # Act / Assert
+        with warnings.catch_warnings(), self.assertRaisesRegex(
+            pylast.WSError, "Deprecated - This type of request is no longer supported"
+        ):
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            lastfm_user.get_artist_tracks(artist="Test Artist")
+
 
 if __name__ == "__main__":
     unittest.main(failfast=True)


### PR DESCRIPTION
Continuation of https://github.com/pylast/pylast/issues/298.

Changes proposed in this pull request:

 * Last.fm's `user.getArtistTracks` has now been deprecated by Last.fm and is no longer available
 * Last.fm returns a "Deprecated - This type of request is no longer supported" error when calling it
 * Change one test which called it to check for this error
 * Remove another test which called it
 * A future version of pylast will remove its `User.get_artist_tracks` altogether
