### PR TITLE
Store Album Art URLs when you call GetTopAlbums.

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2896,8 +2896,9 @@ def _extract_top_albums(doc, network):
         name = _extract(node, "name")
         artist = _extract(node, "name", 1)
         playcount = _extract(node, "playcount")
+        info = {"image": _extract_all(node, "image")}
 
-        seq.append(TopItem(Album(artist, name, network), playcount))
+        seq.append(TopItem(Album(artist, name, network, info=info), playcount))
 
     return seq
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -271,6 +271,12 @@ class TestPyLastUser(TestPyLastWithLastFm):
         # Assert
         self.helper_only_one_thing_in_top_list(albums, pylast.Album)
 
+        top_album = albums[0].item
+        self.assertTrue(len(top_album.info["image"]))
+        self.assertRegexpMatches(
+            top_album.info["image"][pylast.SIZE_LARGE], r"^http.+$"
+        )
+
     def test_user_tagged_artists(self):
         # Arrange
         lastfm_user = self.network.get_user(self.username)


### PR DESCRIPTION
The `GetTopAlbums` API call returns album art information with each album in the top album list.
We should store this in the `Album() `info variable, so we don't have to follow up with an additional `GetInfo()` call if we want the Album Art.

This change means that calling both `user.get_top_albums()`, and then `album.get_cover_image()`, only requires a single API Call.

Changes proposed in this pull request:

 *` _extract_top_albums()` now extracts Image URLs from the returned `GetTopAlbumResponse`
 * This is saved to a dict, which is passed to an `Album()` constructor as info.
 * This adds an additional assert in `test_user.py`
