### PR TITLE
Update get_weekly_artist_charts docstring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v1.24.0
+    hooks:
+      - id: pyupgrade
+
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+        language_version: python3.7
+        # override until resolved: https://github.com/psf/black/issues/402
+        files: \.pyi?$
+        types: []
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.8
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-2020]
+
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+      - id: isort
+        language_version: python3.7
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.4.1
+    hooks:
+      - id: python-check-blanket-noqa
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
       env: TOXENV=lint
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
     - python: 3.6
       env: TOXENV=py36
     - python: 3.5
@@ -27,7 +26,6 @@ matrix:
       env: TOXENV=pypy3
     - python: 3.8-dev
       env: TOXENV=py38dev
-      dist: xenial
   allow_failures:
     - env: TOXENV=pypy3
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ env:
   - secure: SsKJoJwtDVWrL5xxl9C/gTRy6FhfRQQNNAFOogl9mTs/WeI2t9QTYoKsxLPXOdoRdu4MvT3h/B2sjwggt7zP81fBVxQRTkg4nq0zSHlj0NqclbFa6I5lUYdGwH9gPk/HWJJwXhKRDsqn/iRw2v+qBDs/j3kIgPQ0yjM58LEPXic=
 
 matrix:
+  fast_finish: true
   include:
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=lint
     - python: 3.7
       env: TOXENV=py37
@@ -28,7 +29,6 @@ matrix:
       env: TOXENV=py38dev
   allow_failures:
     - env: TOXENV=pypy3
-  fast_finish: true
 
 install:
 - travis_retry pip install --upgrade pip
@@ -49,7 +49,7 @@ deploy:
       tags: false
       repo: pylast/pylast
       branch: master
-      condition: $TOXENV = py37
+      condition: $TOXENV = lint
     user: hugovk
     password:
       secure: "OCNT7Sf7TpS6aKuqBXEWxJZjmEpdERTBp/yllOd9xnpFt2ZL96CyKtAhPA8zu5OP58QFEZSafZRfXYJoz78RDrx3gOdRXCFT00vXIMnjVvrAlieNEHCVAT0kRW9lYK1Cf5baHYsOYIs6EZf2fEAhdzvmh83G4Y1Y+FPR9tA6uy8="
@@ -60,7 +60,7 @@ deploy:
       tags: true
       repo: pylast/pylast
       branch: master
-      condition: $TOXENV = py37
+      condition: $TOXENV = lint
     user: hugovk
     password:
       secure: "OCNT7Sf7TpS6aKuqBXEWxJZjmEpdERTBp/yllOd9xnpFt2ZL96CyKtAhPA8zu5OP58QFEZSafZRfXYJoz78RDrx3gOdRXCFT00vXIMnjVvrAlieNEHCVAT0kRW9lYK1Cf5baHYsOYIs6EZf2fEAhdzvmh83G4Y1Y+FPR9tA6uy8="

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1251,7 +1251,7 @@ class _Chartable:
         """
         Returns the weekly artist charts for the week starting from the
         from_date value to the to_date value.
-        Only for Tag or User.
+        Only for User.
         """
         return self.get_weekly_charts("artist", from_date, to_date)
 

--- a/tests/test_librefm.py
+++ b/tests/test_librefm.py
@@ -4,9 +4,8 @@ Integration (not unit) tests for pylast.py
 """
 import unittest
 
-from flaky import flaky
-
 import pylast
+from flaky import flaky
 
 from .test_pylast import PyLastTestCase, load_secrets
 

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -7,11 +7,9 @@ import sys
 import time
 import unittest
 
+import pylast
 import pytest
 from flaky import flaky
-
-import pylast
-
 
 PY37 = sys.version_info[:2] == (3, 7)
 

--- a/tests/unicode_test.py
+++ b/tests/unicode_test.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
-import pytest
-
 import pylast
+import pytest
 
 
 def mock_network():

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,6 @@ deps = ipdb
 commands = {posargs}
 
 [testenv:lint]
-deps =
-    flake8
-    pep8-naming
-    black
-commands =
-    flake8 .
-    black --check --diff .
+deps = pre-commit
+commands = pre-commit run --all-files
+skip_install = true


### PR DESCRIPTION
Fixes #308.

Looks like Last.fm removed `tag.get_weekly_artist_charts` / `Tag.getWeeklyArtistChart` as part of their "re-imagining". It's no longer listed on the API page:

* https://www.last.fm/api/

It was removed from the docs between 13 and 14th January 2016:

* https://web.archive.org/web/20160113041418/http://www.last.fm/api
* https://web.archive.org/web/20160114204951/http://www.last.fm/api

There's also no test for `tag.get_weekly_artist_charts`.

This updates the docstring, and also adds pre-commit for lint.