### PR TITLE
Use setuptools_scm to simplify versioning during release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-graft src
-include setup.py
-include README.md
-include COPYING
-recursive-include tests *.py

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,40 +1,30 @@
 # Release Checklist
 
-* [ ] Get master to the appropriate code release state. [Travis CI](https://travis-ci.org/pylast/pylast) should be running cleanly for all merges to master.
-* [ ] Remove `.dev0` suffix from the version and update version and date in the changelog:
+* [ ] Get master to the appropriate code release state.
+      [Travis CI](https://travis-ci.org/pylast/pylast) should be running cleanly for
+      all merges to master.
+
+* [ ] Tag with the version number:
+
 ```bash
-git checkout master
-edit CHANGELOG.md src/pylast/version.py
-```
-* [ ] Commit and tag with the version number:
-```bash
-git add CHANGELOG.md src/pylast/version.py
-git commit -m "Release 3.0.0"
-git tag -a 3.0.0 -m "Release 3.0.0"
+git tag -a 3.2.0 -m "Release 3.2.0"
 ```
 
-* [ ] Push commits and tags:
- ```bash
-git push
+* [ ] Push tag:
+
+```bash
 git push --tags
 ```
 
 * [ ] Create new GitHub release: https://github.com/pylast/pylast/releases/new
-  * Tag: Pick existing tag "3.0.0"
-  * Title: "Release 3.0.0"
 
-* [ ] Check the tagged [Travis CI build](https://travis-ci.org/pylast/pylast) has deployed to [PyPI](https://pypi.org/project/pylast/#history)
+  * Tag: Pick existing tag "3.2.0"
 
-* [ ] Check installation: `pip3 uninstall -y pylast && pip3 install -U pylast`
+* [ ] Check the tagged [Travis CI build](https://travis-ci.org/pylast/pylast) has
+      deployed to [PyPI](https://pypi.org/project/pylast/#history)
 
-* [ ] Increment version and append `.dev0`, and add Unreleased to the changelog:
+* [ ] Check installation:
+
 ```bash
-git checkout master
-edit CHANGELOG.md src/pylast/version.py
-```
-* [ ] Commit and push:
-```bash
-git add CHANGELOG.md src/pylast/version.py
-git commit -m "Start new release cycle"
-git push
+pip3 uninstall -y pylast && pip3 install -U pylast
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
-#!/usr/bin/env python
 from setuptools import find_packages, setup
-
-version_dict = {}
-with open("src/pylast/version.py") as f:
-    exec(f.read(), version_dict)
-    version = version_dict["__version__"]
-
 
 with open("README.md") as f:
     long_description = f.read()
+
+
+def local_scheme(version):
+    """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
+    to be able to upload to Test PyPI"""
+    return ""
 
 
 setup(
@@ -16,10 +15,15 @@ setup(
     description="A Python interface to Last.fm and Libre.fm",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version=version,
     author="Amr Hassan <amr.hassan@gmail.com> and Contributors",
     author_email="amr.hassan@gmail.com",
     url="https://github.com/pylast/pylast",
+    license="Apache2",
+    keywords=["Last.fm", "music", "scrobble", "scrobbling"],
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    use_scm_version={"local_scheme": local_scheme},
+    setup_requires=["setuptools_scm"],
     extras_require={
         "tests": ["flaky", "pytest", "pytest-cov", "pytest-random-order", "pyyaml"]
     },
@@ -39,10 +43,6 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    keywords=["Last.fm", "music", "scrobble", "scrobbling"],
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    license="Apache2",
 )
 
 # End of file

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -33,13 +33,13 @@ from http.client import HTTPSConnection
 from urllib.parse import quote_plus
 from xml.dom import Node, minidom
 
-from . import version
+import pkg_resources
 
 __author__ = "Amr Hassan, hugovk, Mice Pápai"
 __copyright__ = "Copyright (C) 2008-2010 Amr Hassan, 2013-2019 hugovk, 2017 Mice Pápai"
 __license__ = "apache2"
 __email__ = "amr.hassan@gmail.com"
-__version__ = version.__version__
+__version__ = pkg_resources.get_distribution(__name__).version
 
 
 # 1 : This error does not exist

--- a/src/pylast/version.py
+++ b/src/pylast/version.py
@@ -1,2 +1,0 @@
-# Master version for pylast
-__version__ = "3.2.0.dev0"


### PR DESCRIPTION
No editing of files, just add the version tag.

Can check with:

```console
$ python setup.py --version
3.1.1.dev45
```
