### PR TITLE
Fix regression calling get_recent_tracks with limit=None

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,12 +31,12 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.4
+    rev: v1.5.1
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2358,7 +2358,11 @@ class User(_BaseObject, _Chartable):
 
         seq = []
         for track in _collect_nodes(
-            limit + 1, self, self.ws_prefix + ".getRecentTracks", cacheable, params
+            limit + 1 if limit else None,
+            self,
+            self.ws_prefix + ".getRecentTracks",
+            cacheable,
+            params,
         ):
 
             if track.hasAttribute("nowplaying"):
@@ -2374,8 +2378,10 @@ class User(_BaseObject, _Chartable):
                 PlayedTrack(Track(artist, title, self.network), album, date, timestamp)
             )
 
-        # Slice, in case we didn't remove a now playing track
-        return seq[:limit]
+        if limit:
+            # Slice, in case we didn't remove a now playing track
+            seq = seq[:limit]
+        return seq
 
     def get_country(self):
         """Returns the name of the country of the user."""

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -2,6 +2,8 @@
 """
 Integration (not unit) tests for pylast.py
 """
+import calendar
+import datetime as dt
 import os
 import unittest
 import warnings
@@ -354,12 +356,8 @@ class TestPyLastUser(TestPyLastWithLastFm):
     def test_get_recent_tracks_from_to(self):
         # Arrange
         lastfm_user = self.network.get_user("RJ")
-
-        from datetime import datetime
-
-        start = datetime(2011, 7, 21, 15, 10)
-        end = datetime(2011, 7, 21, 15, 15)
-        import calendar
+        start = dt.datetime(2011, 7, 21, 15, 10)
+        end = dt.datetime(2011, 7, 21, 15, 15)
 
         utc_start = calendar.timegm(start.utctimetuple())
         utc_end = calendar.timegm(end.utctimetuple())
@@ -371,6 +369,25 @@ class TestPyLastUser(TestPyLastWithLastFm):
         self.assertEqual(len(tracks), 1)
         self.assertEqual(str(tracks[0].track.artist), "Johnny Cash")
         self.assertEqual(str(tracks[0].track.title), "Ring of Fire")
+
+    def test_get_recent_tracks_limit_none(self):
+        # Arrange
+        lastfm_user = self.network.get_user("bbc6music")
+        start = dt.datetime(2020, 2, 15, 15, 00)
+        end = dt.datetime(2020, 2, 15, 15, 40)
+
+        utc_start = calendar.timegm(start.utctimetuple())
+        utc_end = calendar.timegm(end.utctimetuple())
+
+        # Act
+        tracks = lastfm_user.get_recent_tracks(
+            time_from=utc_start, time_to=utc_end, limit=None
+        )
+
+        # Assert
+        self.assertEqual(len(tracks), 11)
+        self.assertEqual(str(tracks[0].track.artist), "Seun Kuti & Egypt 80")
+        self.assertEqual(str(tracks[0].track.title), "Struggles Sounds")
 
     def test_get_playcount(self):
         # Arrange

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py38, py37, py36, py35, pypy3
-recreate = False
 
 [testenv]
 extras = tests


### PR DESCRIPTION
Fixes #313.

Changes proposed in this pull request:

 * Fix a regression introduced in https://github.com/pylast/pylast/pull/310
 * Allow `get_recent_tracks` to be called with `limit=None`

