### PR TITLE
Use Release Drafter to draft releases

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,11 +4,15 @@
 
 ### What actually happened?
 
-### What versions of OS, Python and pylast are you using?
+### What versions are you using?
+
+* OS: 
+* Python: 
+* pylast: 
 
 Please include **code** that reproduces the issue.
 
-The [best reproductions](https://stackoverflow.com/help/mcve) are [self-contained scripts](https://ericlippert.com/2014/03/05/how-to-debug-small-programs/) with minimal dependencies.
+The [best reproductions](https://stackoverflow.com/help/minimal-reproducible-example) are [self-contained scripts](https://ericlippert.com/2014/03/05/how-to-debug-small-programs/) with minimal dependencies.
 
 ```python
 code goes here

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,96 @@
+# Default GitHub labels
+- color: d73a4a
+  description: "Something isn't working"
+  name: bug
+- color: cfd3d7
+  description: "This issue or pull request already exists"
+  name: duplicate
+- color: a2eeef
+  description: "New feature or request"
+  name: enhancement
+- color: 7057ff
+  description: "Good for newcomers"
+  name: good first issue
+- color: 008672
+  description: "Extra attention is needed"
+  name: help wanted
+- color: e4e669
+  description: "This doesn't seem right"
+  name: invalid
+- color: d876e3
+  description: "Further information is requested"
+  name: question
+- color: ffffff
+  description: "This will not be worked on"
+  name: wontfix
+
+# Keep a Changelog labels
+# https://keepachangelog.com/en/1.0.0/
+- color: 0e8a16
+  description: "For new features"
+  name: "changelog: Added"
+- color: af99e5
+  description: "For changes in existing functionality"
+  name: "changelog: Changed"
+- color: FFA500
+  description: "For soon-to-be removed features"
+  name: "changelog: Deprecated"
+- color: 00A800
+  description: "For any bug fixes"
+  name: "changelog: Fixed"
+- color: ff0000
+  description: "For now removed features"
+  name: "changelog: Removed"
+- color: 045aa0
+  description: "In case of vulnerabilities"
+  name: "changelog: Security"
+- color: fbca04
+  description: "Exclude PR from release draft"
+  name: "changelog: skip"
+
+# Other labels
+- color: e11d21
+  description: ""
+  name: Last.fm bug
+- color: FFFFFF
+  description: ""
+  name: Milestone-0.3
+- color: FFFFFF
+  description: ""
+  name: Performance
+- color: FFFFFF
+  description: ""
+  name: Priority-High
+- color: FFFFFF
+  description: ""
+  name: Priority-Low
+- color: FFFFFF
+  description: ""
+  name: Priority-Medium
+- color: FFFFFF
+  description: ""
+  name: Type-Other
+- color: FFFFFF
+  description: ""
+  name: Type-Patch
+- color: FFFFFF
+  description: ""
+  name: Usability
+- color: 64c1c0
+  description: ""
+  name: backwards incompatible
+- color: fef2c0
+  description: ""
+  name: build
+- color: e99695
+  description: Feature that will be removed in the future
+  name: deprecation
+- color: FFFFFF
+  description: ""
+  name: imported
+- color: b60205
+  description: Removal of a feature, usually done in major releases
+  name: removal
+- color: fef2c0
+  description: ""
+  name: test

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: "$NEXT_PATCH_VERSION"
+tag-template: "$NEXT_PATCH_VERSION"
+
+categories:
+  - title: "Added"
+    labels:
+      - "changelog: Added"
+      - "enhancement"
+  - title: "Changed"
+    label: "changelog: Changed"
+  - title: "Deprecated"
+    label: "changelog: Deprecated"
+  - title: "Removed"
+    label: "changelog: Removed"
+  - title: "Fixed"
+    labels:
+      - "changelog: Fixed"
+      - "bug"
+  - title: "Security"
+    label: "changelog: Security"
+
+exclude-labels:
+  - "changelog: skip"
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,15 @@
+name: Sync labels
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    if: github.repository == 'pylast/pylast'
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next release notes as pull requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.1.0
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
@@ -21,7 +21,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
+    rev: v2.1.0
     hooks:
       - id: seed-isort-config
 
@@ -31,12 +31,12 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.4
+    rev: v1.5.1
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -19,7 +19,7 @@ def load_secrets():
     if os.path.isfile(secrets_file):
         import yaml  # pip install pyyaml
 
-        with open(secrets_file, "r") as f:  # see example_test_pylast.yaml
+        with open(secrets_file) as f:  # see example_test_pylast.yaml
             doc = yaml.load(f)
     else:
         doc = {}


### PR DESCRIPTION
Changes proposed in this pull request:

 * Use https://github.com/micnncim/action-label-syncer to import labels for use with https://keepachangelog.com/en/1.0.0/
  * Existing labels were first exported using https://github.com/micnncim/label-exporter
 * Use https://github.com/release-drafter/release-drafter to draft a release as PRs are merged, using Keep a Changelog labels

RELEASING.md will need updating, will do so after the next release.
