### PR TITLE
GHA: Fix lint cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: lint-pre-commit-v1-${{ hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
-            lint-pre-commit-
+            lint-pre-commit-v1-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
-          key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          key: lint-pre-commit-v1-${{ hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
             lint-pre-commit-
 

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,3 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )
-
-# End of file


### PR DESCRIPTION
For some reason, when the last PR was merged, the lint failed because of an apparently outdated cache:

```
Run tox -e lint
lint create: /home/runner/work/pylast/pylast/.tox/lint
lint installdeps: pre-commit
lint installed: appdirs==1.4.3,cfgv==3.1.0,distlib==0.3.0,filelock==3.0.12,identify==1.4.11,nodeenv==1.3.5,pre-commit==2.1.1,PyYAML==5.3,six==1.14.0,toml==0.10.0,virtualenv==20.0.8
lint run-test-pre: PYTHONHASHSEED='3856264503'
lint run-test: commands[0] | pre-commit run --all-files
pyupgrade................................................................Failed
- hook id: pyupgrade
- exit code: 1

Executable `/home/runner/.cache/pre-commit/repoy32i7vy1/py_env-python3.8/bin/python` not found

black....................................................................Failed
- hook id: black
- exit code: 1

Executable `/home/runner/.cache/pre-commit/repo4hkcvbl4/py_env-python3/bin/python` not found

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

Executable `/home/runner/.cache/pre-commit/repo0nx3ym4i/py_env-python3.8/bin/python` not found

seed isort known_third_party.............................................Failed
- hook id: seed-isort-config
- exit code: 1
```

* https://github.com/pylast/pylast/runs/485929900?check_suite_focus=true

There's no way (yet) to delete caches on GHA, you need to stick a version number in the key instead.