### PR TITLE
Fix DeprecationWarning: Please use assertRegex instead

### DIFF
--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -277,9 +277,7 @@ class TestPyLastUser(TestPyLastWithLastFm):
 
         top_album = albums[0].item
         self.assertTrue(len(top_album.info["image"]))
-        self.assertRegexpMatches(
-            top_album.info["image"][pylast.SIZE_LARGE], r"^http.+$"
-        )
+        self.assertRegex(top_album.info["image"][pylast.SIZE_LARGE], r"^http.+$")
 
     def test_user_tagged_artists(self):
         # Arrange


### PR DESCRIPTION
> _New in version 3.5_: The name `assertNotRegexpMatches` is a deprecated alias for `assertNotRegex()`.

https://docs.python.org/3.5/library/unittest.html#unittest.TestCase.assertRegexpMatches