### PR TITLE
Improve handling of error responses from the API

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -932,7 +932,15 @@ class _Request:
                 raise NetworkError(self.network, e)
 
         try:
-            response_text = _unicode(conn.getresponse().read())
+            response = conn.getresponse()
+            if response.status in [500, 502, 503, 504]:
+                raise WSError(
+                    self.network,
+                    response.status,
+                    "Connection to the API failed with HTTP code "
+                    + str(response.status),
+                )
+            response_text = _unicode(response.read())
         except Exception as e:
             raise MalformedResponseError(self.network, e)
 


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

 * Raise a WSError if the API response contains a non-200 code, instead of failing to interpret the body and raising a MalformedResponseError