### PR TITLE
Deprecate Artist.get_cover_image, they're no longer available from Last.fm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.4.4
+    rev: v2.6.1
     hooks:
       - id: pyupgrade
         args: ["--py3-plus"]
@@ -15,13 +15,13 @@ repos:
         types: []
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.2
+    rev: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.1
+    rev: v2.2.0
     hooks:
       - id: seed-isort-config
 

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1726,6 +1726,15 @@ class Artist(_BaseObject, _Taggable):
             SIZE_SMALL
         """
 
+        warnings.warn(
+            "Artist.get_cover_image is deprecated and will be removed in a future "
+            "version. In the meantime, only default star images are available. "
+            "See https://github.com/pylast/pylast/issues/317 and "
+            "https://support.last.fm/t/api-announcement/202",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if "image" not in self.info:
             self.info["image"] = _extract_all(
                 self._request(self.ws_prefix + ".getInfo", cacheable=True), "image"

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -250,7 +250,10 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         # Act
         url = artist1.get_url()
         mbid = artist1.get_mbid()
-        image = artist1.get_cover_image()
+
+        with pytest.warns(DeprecationWarning):
+            image = artist1.get_cover_image()
+
         playcount = artist1.get_playcount()
         streamable = artist1.is_streamable()
         name = artist1.get_name(properly_capitalized=False)

--- a/tox.ini
+++ b/tox.ini
@@ -16,5 +16,6 @@ commands = {posargs}
 
 [testenv:lint]
 deps = pre-commit
-commands = pre-commit run --all-files
+commands = pre-commit run --all-files --show-diff-on-failure
 skip_install = true
+passenv = PRE_COMMIT_COLOR


### PR DESCRIPTION
Fixes #317.

Changes proposed in this pull request:

 * [Last.fm announced](https://support.last.fm/t/api-announcement/202) that artist images were never meant to be available, in line with their API Terms of Use
 * They replaced the images with default star images
 * We therefore don't need to maintain `Artist.get_cover_image` in the future, so let's deprecate it first
