### PR TITLE
Only test write operations on a single Python version to avoid collision failures

### DIFF
--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -5,7 +5,7 @@ Integration (not unit) tests for pylast.py
 import pylast
 import pytest
 
-from .test_pylast import TestPyLastWithLastFm
+from .test_pylast import WRITE_TEST, TestPyLastWithLastFm
 
 
 class TestPyLastArtist(TestPyLastWithLastFm):
@@ -141,6 +141,7 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         assert isinstance(count, int)
         assert count > 0
 
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_tag_artist(self):
         # Arrange
         artist = self.network.get_artist("Test Artist")
@@ -159,6 +160,7 @@ class TestPyLastArtist(TestPyLastWithLastFm):
                 break
         assert found
 
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_remove_tag_of_type_text(self):
         # Arrange
         tag = "testing"  # text
@@ -177,6 +179,7 @@ class TestPyLastArtist(TestPyLastWithLastFm):
                 break
         assert not found
 
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_remove_tag_of_type_tag(self):
         # Arrange
         tag = pylast.Tag("testing", self.network)  # Tag
@@ -195,6 +198,7 @@ class TestPyLastArtist(TestPyLastWithLastFm):
                 break
         assert not found
 
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_remove_tags(self):
         # Arrange
         tags = ["removetag1", "removetag2"]
@@ -218,6 +222,7 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         assert not found1
         assert not found2
 
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_set_tags(self):
         # Arrange
         tags = ["sometag1", "sometag2"]

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -8,11 +8,11 @@ import time
 import pylast
 import pytest
 
-from .test_pylast import PY37, TestPyLastWithLastFm
+from .test_pylast import WRITE_TEST, TestPyLastWithLastFm
 
 
 class TestPyLastNetwork(TestPyLastWithLastFm):
-    @pytest.mark.skipif(not PY37, reason="Only run on Python 3.7 to avoid collisions")
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_scrobble(self):
         # Arrange
         artist = "test artist"
@@ -30,6 +30,7 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
         assert str(last_scrobble.track.artist).lower() == artist
         assert str(last_scrobble.track.title).lower() == title
 
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_update_now_playing(self):
         # Arrange
         artist = "Test Artist"

--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -10,7 +10,7 @@ import pylast
 import pytest
 from flaky import flaky
 
-PY37 = sys.version_info[:2] == (3, 7)
+WRITE_TEST = sys.version_info[:2] == (3, 8)
 
 
 def load_secrets():

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -7,10 +7,11 @@ import time
 import pylast
 import pytest
 
-from .test_pylast import PY37, TestPyLastWithLastFm
+from .test_pylast import WRITE_TEST, TestPyLastWithLastFm
 
 
 class TestPyLastTrack(TestPyLastWithLastFm):
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_love(self):
         # Arrange
         artist = "Test Artist"
@@ -26,7 +27,7 @@ class TestPyLastTrack(TestPyLastWithLastFm):
         assert str(loved[0].track.artist).lower() == "test artist"
         assert str(loved[0].track.title).lower() == "test title"
 
-    @pytest.mark.skipif(not PY37, reason="Only run on Python 3.7 to avoid collisions")
+    @pytest.mark.skipif(not WRITE_TEST, reason="Only test once to avoid collisions")
     def test_unlove(self):
         # Arrange
         artist = pylast.Artist("Test Artist", self.network)


### PR DESCRIPTION
Changes proposed in this pull request:

 * Because test are run using a real (test) account on Last.fm, sometimes one of the parallel jobs changes the state on the network and causes another job to fail (eg. last `master` https://travis-ci.org/github/pylast/pylast/builds/701542153)
 * Let's only do write tests with a single Python version/CI job (currently 3.8), to isolate potential conflicts

