### PR TITLE
Return None for MBID when track not found

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1592,7 +1592,10 @@ class _Opus(_BaseObject, _Taggable):
     def get_mbid(self):
         """Returns the MusicBrainz ID of the album or track."""
 
-        doc = self._request(self.ws_prefix + ".getInfo", cacheable=True)
+        try:
+            doc = self._request(self.ws_prefix + ".getInfo", cacheable=True)
+        except WSError:
+            return None
 
         try:
             lfm = doc.getElementsByTagName("lfm")[0]

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1594,8 +1594,10 @@ class _Opus(_BaseObject, _Taggable):
 
         try:
             doc = self._request(self.ws_prefix + ".getInfo", cacheable=True)
-        except WSError:
-            return None
+        except WSError as e:
+            if int(e.get_id()) == STATUS_INVALID_PARAMS and str(e) == "Track not found":
+                return None
+            raise
 
         try:
             lfm = doc.getElementsByTagName("lfm")[0]

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -241,9 +241,16 @@ class TestPyLastTrack(TestPyLastWithLastFm):
         # Assert
         assert corrected_track_name == "Mr. Brownstone"
 
-    def test_track_with_no_mbid(self):
+    @pytest.mark.parametrize(
+        ("test_artist", "test_track"),
+        [
+            ("Static-X", "Set It Off"),  # Track with no MBID
+            ("Zytaris", "Shores of Life"),  # "Track not found"
+        ],
+    )
+    def test_track_with_no_mbid(self, test_artist, test_track):
         # Arrange
-        track = pylast.Track("Static-X", "Set It Off", self.network)
+        track = pylast.Track(test_track, test_artist, self.network)
 
         # Act
         mbid = track.get_mbid()


### PR DESCRIPTION
Fixes #340.

Changes proposed in this pull request:

 * Getting MBID for a track which Last.fm raises `pylast.WSError: Track not found`, even if the track was returned by `get_recent_tracks`
 * In this case, return `None` instead
 * Other things that call `getInfo` on a "Track not found" will also raise an exception, but let's deal with those if and when they come up. And it may be a good idea for user code to handle `WSError` exceptions.

Here's the XML for three types of tracks, and the `get_mbid` return before this PR.

# Track not found

```xml
<lfm status="failed">
	<error code="6">Track not found</error>
</lfm>
```

https://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=YOUR_API_KEY&artist=Zytaris&track=Shores%20of%20Life

```
Traceback (most recent call last):
  File "1.py", line 40, in <module>
    print(track.get_mbid())
  File "/Users/hugo/github/pylast/src/pylast/__init__.py", line 1595, in get_mbid
    doc = self._request(self.ws_prefix + ".getInfo", cacheable=True)
  File "/Users/hugo/github/pylast/src/pylast/__init__.py", line 1126, in _request
    return _Request(self.network, method_name, params).execute(cacheable)
  File "/Users/hugo/github/pylast/src/pylast/__init__.py", line 959, in execute
    response = self._download_response()
  File "/Users/hugo/github/pylast/src/pylast/__init__.py", line 948, in _download_response
    self._check_response_for_errors(response_text)
  File "/Users/hugo/github/pylast/src/pylast/__init__.py", line 978, in _check_response_for_errors
    raise WSError(self.network, status, details)
pylast.WSError: Track not found
```

# Track found but no MBID

```xml
<lfm status="ok">
	<track>
		<name>Purple Glitter</name>
		<url>https://www.last.fm/music/Oranj+Goodman/_/Purple+Glitter</url>
		<duration>0</duration>
		<streamable fulltrack="0">0</streamable>
		<listeners>4</listeners>
		<playcount>4</playcount>
		<artist>
			<name>Oranj Goodman</name>
			<url>https://www.last.fm/music/Oranj+Goodman</url>
		</artist>
		<toptags/>
	</track>
</lfm>
```

https://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=YOUR_API_KEY&artist=Oranj%20Goodman&track=Purple%20Glitter

```
None
```

# Track and MBID found

```xml
<lfm status="ok">
	<track>
		<name>Believe</name>
		<mbid>32ca187e-ee25-4f18-b7d0-3b6713f24635</mbid>
		<url>https://www.last.fm/music/Cher/_/Believe</url>
		<duration>234000</duration>
		<streamable fulltrack="0">0</streamable>
		<listeners>523527</listeners>
		<playcount>2648559</playcount>
		<artist>
			<name>Cher</name>
			<mbid>bfcc6d75-a6a5-4bc6-8282-47aec8531818</mbid>
			<url>https://www.last.fm/music/Cher</url>
		</artist>
		<album position="1">
			<artist>Cher</artist>
			<title>Believe</title>
			<mbid>63b3a8ca-26f2-4e2b-b867-647a6ec2bebd</mbid>
			<url>https://www.last.fm/music/Cher/Believe</url>
			<image size="small">https://lastfm.freetls.fastly.net/i/u/34s/3b54885952161aaea4ce2965b2db1638.png</image>
			<image size="medium">https://lastfm.freetls.fastly.net/i/u/64s/3b54885952161aaea4ce2965b2db1638.png</image>
			<image size="large">https://lastfm.freetls.fastly.net/i/u/174s/3b54885952161aaea4ce2965b2db1638.png</image>
			<image size="extralarge">https://lastfm.freetls.fastly.net/i/u/300x300/3b54885952161aaea4ce2965b2db1638.png</image>
		</album>
		<toptags>
			<tag>
				<name>pop</name>
				<url>https://www.last.fm/tag/pop</url>
			</tag>
			<tag>
				<name>dance</name>
				<url>https://www.last.fm/tag/dance</url>
			</tag>
			<tag>
				<name>90s</name>
				<url>https://www.last.fm/tag/90s</url>
			</tag>
			<tag>
				<name>cher</name>
				<url>https://www.last.fm/tag/cher</url>
			</tag>
			<tag>
				<name>female vocalists</name>
				<url>https://www.last.fm/tag/female+vocalists</url>
			</tag>
		</toptags>
		<wiki>
			<published>27 Jul 2008, 15:44</published>
			<summary>"Believe" is a Grammy Award winning global number one, Multi-Platinum Dance Song which served as the world-wide lead single for American singer Cher's twenty-third studio album Believe. It is noted for its use of a peculiar sound effect on the singer's vocals, which is referred to as the Cher effect today. "Believe" was written by a number of writers including Paul Barry, Matt Gray, Brian Higgins, Stuart McLellan, Timothy Powell, and Steven Torch. 
				<a href="http://www.last.fm/music/Cher/_/Believe">Read more on Last.fm</a>.
			</summary>
			<content>"Believe" is a Grammy Award winning global number one, Multi-Platinum Dance Song which served as the world-wide lead single for American singer Cher's twenty-third studio album Believe. It is noted for its use of a peculiar sound effect on the singer's vocals, which is referred to as the Cher effect today. "Believe" was written by a number of writers including Paul Barry, Matt Gray, Brian Higgins, Stuart McLellan, Timothy Powell, and Steven Torch. The song, released and recorded in 1998, peaked at number one in 23 countries worldwide .In the second week of March, 1999, it reached number one in the Billboard Hot 100, making Cher the oldest female artist (at the age of 52) to perform this feat. It also was ranked as the number-one song of 1999 by Billboard, and became the biggest single in her entire career. "Believe" also spent seven weeks at number one] in the UK singles chart and is still the best selling single by a female artist in the UK. In March 2007, the United World Chart ranked "Believe" as the sixteenth most successful song in music history. The same chart lists "Believe" as third most successful song released by a solo female musician behind Whitney Houston's "I Will Always Love You" and Celine Dion's My Heart Will Go On; [5], the biggest selling single ever for Warner Bros. Records and the biggest selling dance song ever having sold over 10 million copies worldwide. It was also the song with most weeks in the top ten, it stayed in the top ten for 28 weeks. The success of the song not only expanded through each country's singles chart, but also most country's dance charts. In the United States "Believe" spent 23 weeks on the U.S. Hot Dance Club Play chart and 22 weeks on the European Hot Dance Charts. "Believe" also set a record in 1999 after spending 21 weeks in the top spot of the Billboard Hot Dance Singles Sales chart, it was still in the top ten even one year after its entry on the chart. "Believe" was given the featured closing number spot for over 100 performances on Cher's 1999-2000 Do You Believe? Tour and then again the closing spot for over 300 performances on Cher's epic 2002-2005 Living Proof: The Farewell Tour. The song ranked #74 on VH1's 100 Greatest Songs of the 90s. An interesting note about the recording of the song revolved around the highly-recognizable Auto-tune effect ("Cher effect") utilized in the verses and chorus. Producer Mark Taylor added the effect to Cher's vocal simply as a lark, and in interviews at the time, he claimed to be testing out his recently purchased the 'DigiTech Talker'. However, it later emerged that the effect was not created by a vocoder, but by utilizing extreme (and then unheard) settings on auto-tune.When Cher heard the results, she demanded that the effect remain in the song, and her original vocal be erased, much to the chagrin of her record company, who wanted it removed; upon their suggestion, Cher's response to the record label was "over my dead body!"[citation needed] The vocal effect is caused by a pitch correction speed that is "set too fast for the audio that it is processing." U.S. Billboard Hot 100 Airplay1 U.S. Billboard Hot 1001 U.S. Billboard Hot Dance Club Play1 U.S. Billboard Hot Dance Singles Sales1 U.S. Billboard Hot Adult Contemporary Tracks2 U.S. Billboard Hot Adult Top 40 Tracks2 U.S. Billboard Top 40 Mainstream2 Argentinian Singles Chart2 Australian ARIA Singles Chart1 Austrian Singles Chart2 Belgian Singles Chart1 Brazilian Airplay Chart1 Croatian Singles Chart1 Canadian Singles Chart1 Danish Singles Chart1 Dutch Mega Top 50 Singles Chart1 Dutch Top 401 European Singles Chart1 Finnish Singles Chart6 French Singles Chart1 German Singles Chart1 Irish Singles Chart1 Israeli Singles Chart1 Italian Singles Chart1 Latvian Singles Chart1 Mexican Singles Chart1 New Zealand's Singles Chart1 Norwegian Singles Chart1 Polish Singles Chart1 Spanish Singles Chart1 Swedish Singles Chart1 Swedish Airplay Chart1 Swiss Singles Chart1 UK Singles Chart1 United World Chart1 
				<a href="http://www.last.fm/music/Cher/_/Believe">Read more on Last.fm</a>. User-contributed text is available under the Creative Commons By-SA License; additional terms may apply.
			</content>
		</wiki>
	</track>
</lfm>
```

https://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=YOUR_API_KEY&artist=cher&track=believe

```
2f49744a-56e8-49e5-b454-5be772edda20
```