### PR TITLE
Run xfail tests only once: no point re-running

### DIFF
--- a/tests/test_pylast.py
+++ b/tests/test_pylast.py
@@ -40,7 +40,12 @@ class PyLastTestCase:
         assert str.endswith(suffix, start, end)
 
 
-@flaky(max_runs=3, min_passes=1)
+def _no_xfail_rerun_filter(err, name, test, plugin):
+    for _ in test.iter_markers(name="xfail"):
+        return False
+
+
+@flaky(max_runs=3, min_passes=1, rerun_filter=_no_xfail_rerun_filter)
 class TestPyLastWithLastFm(PyLastTestCase):
 
     secrets = None


### PR DESCRIPTION
Re: https://github.com/box/flaky/issues/168#issuecomment-678698011

# Before

```
tests/test_user.py::TestPyLastUser::test_user_tagged_tracks PASSED
tests/test_user.py::TestPyLastUser::test_user_subscriber PASSED
tests/test_user.py::TestPyLastUser::test_cacheable_user XFAIL
tests/test_user.py::TestPyLastUser::test_cacheable_user XFAIL
tests/test_user.py::TestPyLastUser::test_cacheable_user XFAIL
tests/test_user.py::TestPyLastUser::test_get_playcount PASSED
tests/test_user.py::TestPyLastUser::test_get_weekly_track_charts PASSED
```

https://travis-ci.org/github/pylast/pylast/jobs/720156748

# After

```
tests/test_user.py::TestPyLastUser::test_user_subscriber PASSED
tests/test_user.py::TestPyLastUser::test_user_is_hashable PASSED
tests/test_user.py::TestPyLastUser::test_cacheable_user XFAIL
tests/test_user.py::TestPyLastUser::test_get_url PASSED
tests/test_user.py::TestPyLastUser::test_get_recent_tracks_from_to PASSED
```

https://travis-ci.org/github/pylast/pylast/jobs/720348071
