### PR TITLE
Remove deprecated Artist.get_cover_image, User.get_artist_tracks and STATUS_TOKEN_ERROR

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -27,7 +27,6 @@ import shelve
 import ssl
 import tempfile
 import time
-import warnings
 import xml.dom
 from http.client import HTTPSConnection
 from urllib.parse import quote_plus
@@ -49,9 +48,7 @@ STATUS_AUTH_FAILED = 4
 STATUS_INVALID_FORMAT = 5
 STATUS_INVALID_PARAMS = 6
 STATUS_INVALID_RESOURCE = 7
-# DeprecationWarning: STATUS_TOKEN_ERROR is deprecated and will be
-# removed in a future version. Use STATUS_OPERATION_FAILED instead.
-STATUS_OPERATION_FAILED = STATUS_TOKEN_ERROR = 8
+STATUS_OPERATION_FAILED = 8
 STATUS_INVALID_SK = 9
 STATUS_INVALID_API_KEY = 10
 STATUS_OFFLINE = 11
@@ -1715,32 +1712,6 @@ class Artist(_BaseObject, _Taggable):
 
         return _extract(self._request(self.ws_prefix + ".getCorrection"), "name")
 
-    def get_cover_image(self, size=SIZE_EXTRA_LARGE):
-        """
-        Returns a URI to the cover image
-        size can be one of:
-            SIZE_MEGA
-            SIZE_EXTRA_LARGE
-            SIZE_LARGE
-            SIZE_MEDIUM
-            SIZE_SMALL
-        """
-
-        warnings.warn(
-            "Artist.get_cover_image is deprecated and will be removed in a future "
-            "version. In the meantime, only default star images are available. "
-            "See https://github.com/pylast/pylast/issues/317 and "
-            "https://support.last.fm/t/api-announcement/202",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if "image" not in self.info:
-            self.info["image"] = _extract_all(
-                self._request(self.ws_prefix + ".getInfo", cacheable=True), "image"
-            )
-        return self.info["image"][size]
-
     def get_playcount(self):
         """Returns the number of plays on the network."""
 
@@ -2250,40 +2221,6 @@ class User(_BaseObject, _Chartable):
             )
 
         return self.name
-
-    def get_artist_tracks(self, artist, cacheable=False):
-        """
-        Deprecated by Last.fm.
-        Get a list of tracks by a given artist scrobbled by this user,
-        including scrobble time.
-        """
-
-        warnings.warn(
-            "User.get_artist_tracks is deprecated and will be removed in a future "
-            "version. User.get_track_scrobbles is a partial replacement. "
-            "See https://github.com/pylast/pylast/issues/298",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        params = self._get_params()
-        params["artist"] = artist
-
-        seq = []
-        for track in _collect_nodes(
-            None, self, self.ws_prefix + ".getArtistTracks", cacheable, params
-        ):
-            title = _extract(track, "name")
-            artist = _extract(track, "artist")
-            date = _extract(track, "date")
-            album = _extract(track, "album")
-            timestamp = track.getElementsByTagName("date")[0].getAttribute("uts")
-
-            seq.append(
-                PlayedTrack(Track(artist, title, self.network), album, date, timestamp)
-            )
-
-        return seq
 
     def get_friends(self, limit=50, cacheable=False):
         """Returns a list of the user's friends. """

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -241,16 +241,12 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         url = artist1.get_url()
         mbid = artist1.get_mbid()
 
-        with pytest.warns(DeprecationWarning):
-            image = artist1.get_cover_image()
-
         playcount = artist1.get_playcount()
         streamable = artist1.is_streamable()
         name = artist1.get_name(properly_capitalized=False)
         name_cap = artist1.get_name(properly_capitalized=True)
 
         # Assert
-        assert "https" in image
         assert playcount > 1
         assert artist1 != artist2
         assert name.lower() == name_cap.lower()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -6,7 +6,6 @@ import calendar
 import datetime as dt
 import os
 import re
-import warnings
 
 import pytest
 
@@ -475,15 +474,3 @@ class TestPyLastUser(TestPyLastWithLastFm):
 
         # Assert
         self.helper_validate_results(result1, result2, result3)
-
-    def test_get_artist_tracks_deprecated(self):
-        # Arrange
-        lastfm_user = self.network.get_user(self.username)
-
-        # Act / Assert
-        with warnings.catch_warnings(), pytest.raises(
-            pylast.WSError,
-            match="Deprecated - This type of request is no longer supported",
-        ):
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            lastfm_user.get_artist_tracks(artist="Test Artist")


### PR DESCRIPTION
Fixes #344.

Changes proposed in this pull request:

 * Remove deprecated `Artist.get_cover_image`
 * Remove deprecated `User.get_artist_tracks`
 * Remove deprecated `STATUS_TOKEN_ERROR`
