### PR TITLE
Bugfix for get_userloved and get_userplaycount resulting in an empty response from the server

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -421,7 +421,7 @@ class _Network:
         """
 
         if not file_path:
-            file_path = tempfile.mkstemp(prefix="pylast_tmp_")
+            file_path = tempfile.mktemp(prefix="pylast_tmp_")
 
         self.cache_backend = _ShelfCacheBackend(file_path)
 

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -925,7 +925,12 @@ class _Request:
             conn = HTTPSConnection(context=SSL_CONTEXT, host=host_name)
 
             try:
-                conn.request(method="POST", url=f'{host_subdir}{username}', body=data, headers=headers)
+                conn.request(
+                    method="POST",
+                    url=f"{host_subdir}{username}",
+                    body=data,
+                    headers=headers,
+                )
             except Exception as e:
                 raise NetworkError(self.network, e)
 
@@ -1497,7 +1502,9 @@ class _Opus(_Taggable):
             self.artist = Artist(artist, self.network)
 
         self.title = title
-        self.username = username if username else network.username  # Default to current user
+        self.username = (
+            username if username else network.username
+        )  # Default to current user
         self.info = info
 
     def __repr__(self):

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -888,6 +888,9 @@ class _Request:
         if self.network.limit_rate:
             self.network._delay_call()
 
+        username = self.params.pop("username", None)
+        username = f"?username={username}" if username is not None else ""
+
         data = []
         for name in self.params.keys():
             data.append("=".join((name, quote_plus(_string(self.params[name])))))
@@ -911,7 +914,7 @@ class _Request:
             try:
                 conn.request(
                     method="POST",
-                    url="https://" + host_name + host_subdir,
+                    url=f"https://{host_name}{host_subdir}{username}",
                     body=data,
                     headers=headers,
                 )
@@ -922,7 +925,7 @@ class _Request:
             conn = HTTPSConnection(context=SSL_CONTEXT, host=host_name)
 
             try:
-                conn.request(method="POST", url=host_subdir, body=data, headers=headers)
+                conn.request(method="POST", url=f'{host_subdir}{username}', body=data, headers=headers)
             except Exception as e:
                 raise NetworkError(self.network, e)
 
@@ -1494,7 +1497,7 @@ class _Opus(_Taggable):
             self.artist = Artist(artist, self.network)
 
         self.title = title
-        self.username = username
+        self.username = username if username else network.username  # Default to current user
         self.info = info
 
     def __repr__(self):


### PR DESCRIPTION
Fixes #353 

Changes proposed in this pull request:

 * Default username context of track to the current user if not set
 * LastFM API seems to have problems interpreting the 'username' parameter when it's included in the post body. Since it's only used to retrieve the context of a track/album/artist (afaik) I would propose this as a temporary solution only until LastFM manages to fix this on their end.

Used the following piece of code to reproduce the problem:
```python
import pylast

# You have to have your own unique two values for API_KEY and API_SECRET
# Obtain yours from https://www.last.fm/api/account/create for Last.fm
API_KEY = "***"
API_SECRET = "***"

# In order to perform a write operation you need to authenticate yourself
username = "***"
password_hash = "***"

network = pylast.LastFMNetwork(api_key=API_KEY, api_secret=API_SECRET,
                               username=username, password_hash=password_hash)
track = network.get_authenticated_user().get_recent_tracks(limit=1)[0]
playcount = track.track.get_userplaycount()
print(playcount)
```
Which resulted in:
![image](https://user-images.githubusercontent.com/8818390/103448207-63512600-4c96-11eb-8af3-71695a05c9c9.png)
(32 being my play count for that track)

Also reproduced it with Postman:
**Username in post body**
![image](https://user-images.githubusercontent.com/8818390/103448198-516f8300-4c96-11eb-99bb-fa48249504f9.png)

**Username as query string**
![image](https://user-images.githubusercontent.com/8818390/103448183-18cfa980-4c96-11eb-90d9-00b44284631a.png)

I ran all tests locally and they all passed:
![image](https://user-images.githubusercontent.com/8818390/103448280-9fd15180-4c97-11eb-9d82-7a07a93c4abb.png)
