### PR TITLE
Set `get_top_tracks` limit even if it's `None`, to get unlimited user `top_tracks`

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2531,8 +2531,7 @@ class User(_Chartable):
 
         params = self._get_params()
         params["period"] = period
-        if limit:
-            params["limit"] = limit
+        params["limit"] = limit
 
         return self._get_things("getTopTracks", Track, params, cacheable, stream=stream)
 


### PR DESCRIPTION
To get an unlimited number of top tracks, `_get_things` expects
`params['limit']` to be set to `None`. However, this can't happen here
because `None` is falsy.

Fixes #366.