### PR TITLE
Fix artist.get_bio_content() to return None if bio is empty when getElementsByTagName

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1153,8 +1153,11 @@ class _BaseObject:
     def _extract_cdata_from_request(self, method_name, tag_name, params):
         doc = self._request(method_name, True, params)
 
-        first_child = doc.getElementsByTagName(tag_name)[0].firstChild
+        elements = doc.getElementsByTagName(tag_name)
+        if len(elements) == 0:
+            return None
 
+        first_child = elements[0].firstChild
         if first_child is None:
             return None
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -417,3 +417,15 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
 
         # Assert
         assert int(total) > 10000
+
+    def test_mbid_biography_issue(self):
+        # Arrange
+        mbid = "e2bef0c5-02e7-4505-b87f-90fc96bd70c3"
+
+        # Act
+        artist = self.network.get_artist_by_mbid(mbid)
+
+        # Assert
+        assert isinstance(artist, pylast.Artist)
+        assert artist.name == "Space 92"
+        assert artist.get_bio_content() is None


### PR DESCRIPTION
This Pull Request is related to #326 

* Checking if the code `doc.getElementsByTagName(tag_name)` return at least 1 element in the dictionary.
* Adding tests to be able to return `None` instead of exception:
```
 first_child = doc.getElementsByTagName(tag_name)[0].firstChild
 IndexError: list index out of range
```