### PR TITLE
Fix artist.get_bio_content() when bio is empty + other test fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.23.1
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.7b0
     hooks:
       - id: black
         args: ["--target-version", "py36"]
@@ -15,35 +15,38 @@ repos:
         types: []
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.9.2
+    rev: v1.10.0
     hooks:
       - id: blacken-docs
         args: ["--target-version", "py36"]
         additional_dependencies: [black==20.8b1]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.7.0
+    rev: 5.9.3
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.7.1
+    rev: v1.9.0
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 0.5.0
+    rev: 0.5.1
     hooks:
       - id: tox-ini-fmt
+
+ci:
+  autoupdate_schedule: quarterly

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1798,9 +1798,14 @@ class Artist(_Taggable):
         else:
             params = None
 
-        return self._extract_cdata_from_request(
-            self.ws_prefix + ".getInfo", section, params
-        )
+        try:
+            bio = self._extract_cdata_from_request(
+                self.ws_prefix + ".getInfo", section, params
+            )
+        except IndexError:
+            bio = None
+
+        return bio
 
     def get_bio_published_date(self):
         """Returns the date on which the artist's biography was published."""

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1355,7 +1355,7 @@ class _Taggable(_BaseObject):
             self.remove_tag(tag)
 
     def clear_tags(self):
-        """Clears all the user-set tags. """
+        """Clears all the user-set tags."""
 
         self.remove_tags(*(self.get_tags()))
 
@@ -1702,7 +1702,7 @@ class Artist(_Taggable):
         self.info = info
 
     def __repr__(self):
-        return "pylast.Artist({}, {})".format(repr(self.get_name()), repr(self.network))
+        return f"pylast.Artist({repr(self.get_name())}, {repr(self.network)})"
 
     def __unicode__(self):
         return str(self.get_name())
@@ -1886,7 +1886,7 @@ class Country(_BaseObject):
         self.name = name
 
     def __repr__(self):
-        return "pylast.Country({}, {})".format(repr(self.name), repr(self.network))
+        return f"pylast.Country({repr(self.name)}, {repr(self.network)})"
 
     @_string_output
     def __str__(self):
@@ -1902,7 +1902,7 @@ class Country(_BaseObject):
         return {"country": self.get_name()}
 
     def get_name(self):
-        """Returns the country name. """
+        """Returns the country name."""
 
         return self.name
 
@@ -1964,7 +1964,7 @@ class Library(_BaseObject):
             self.user = User(user, self.network)
 
     def __repr__(self):
-        return "pylast.Library({}, {})".format(repr(self.user), repr(self.network))
+        return f"pylast.Library({repr(self.user)}, {repr(self.network)})"
 
     @_string_output
     def __str__(self):
@@ -2010,7 +2010,7 @@ class Tag(_Chartable):
         self.name = name
 
     def __repr__(self):
-        return "pylast.Tag({}, {})".format(repr(self.name), repr(self.network))
+        return f"pylast.Tag({repr(self.name)}, {repr(self.network)})"
 
     @_string_output
     def __str__(self):
@@ -2026,7 +2026,7 @@ class Tag(_Chartable):
         return {self.ws_prefix: self.get_name()}
 
     def get_name(self, properly_capitalized=False):
-        """Returns the name of the tag. """
+        """Returns the name of the tag."""
 
         if properly_capitalized:
             self.name = _extract(
@@ -2149,12 +2149,12 @@ class Track(_Opus):
         return Album(_extract(node, "artist"), _extract(node, "title"), self.network)
 
     def love(self):
-        """Adds the track to the user's loved tracks. """
+        """Adds the track to the user's loved tracks."""
 
         self._request(self.ws_prefix + ".love")
 
     def unlove(self):
-        """Remove the track to the user's loved tracks. """
+        """Remove the track to the user's loved tracks."""
 
         self._request(self.ws_prefix + ".unlove")
 
@@ -2220,7 +2220,7 @@ class User(_Chartable):
         self.name = user_name
 
     def __repr__(self):
-        return "pylast.User({}, {})".format(repr(self.name), repr(self.network))
+        return f"pylast.User({repr(self.name)}, {repr(self.network)})"
 
     @_string_output
     def __str__(self):
@@ -2259,7 +2259,7 @@ class User(_Chartable):
         return self.name
 
     def get_friends(self, limit=50, cacheable=False, stream=False):
-        """Returns a list of the user's friends. """
+        """Returns a list of the user's friends."""
 
         def _get_friends():
             for node in _collect_nodes(
@@ -2604,7 +2604,7 @@ class User(_Chartable):
         return self.network._get_url(domain_name, "user") % {"name": name}
 
     def get_library(self):
-        """Returns the associated Library object. """
+        """Returns the associated Library object."""
 
         return Library(self, self.network)
 

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -95,4 +95,4 @@ class TestPyLastAlbum(TestPyLastWithLastFm):
 
         # Assert
         self.assert_startswith(image, "https://")
-        self.assert_endswith(image, ".png")
+        self.assert_endswith(image, ".gif")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -267,6 +267,8 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
         assert isinstance(artist, pylast.Artist)
         assert artist.name in ("MusicBrainz Test Artist", "MusicBrainzz Test Artist")
 
+    @pytest.mark.xfail(reason="Broken at Last.fm: Track not found")
+    # https://support.last.fm/t/track-getinfo-with-mbid-returns-6-track-not-found/47905
     def test_track_mbid(self):
         # Arrange
         mbid = "ebc037b1-cc9c-44f2-a21f-83c219f0e1e0"

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -265,7 +265,7 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
 
         # Assert
         assert isinstance(artist, pylast.Artist)
-        assert artist.name == "MusicBrainz Test Artist"
+        assert artist.name in ("MusicBrainz Test Artist", "MusicBrainzz Test Artist")
 
     def test_track_mbid(self):
         # Arrange


### PR DESCRIPTION
Changes proposed in this pull request:

Code fixes:

 * Fix `artist.get_bio_content()` for when bio is empty: previously Last.fm returned `<content/>` (https://github.com/pylast/pylast/pull/326), but now it doesn't even return a `<content/>` section 

Test fixes:

 * xfail `test_track_mbid`: Last.fm is broken and returning "Track not found"
   * https://support.last.fm/t/track-getinfo-with-mbid-returns-6-track-not-found/47905
 * Fix `test_get_cover_image`: the test image is now gif not png
 * Fix `test_artist_mbid`: check more than one title

Test updates:

 * Update pre-commit and add quarterly `autoupdate_schedule`
