### PR TITLE
Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04]
         include:
           # Include new variables for Codecov

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -245,7 +245,7 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
 
     def test_album_mbid(self):
         # Arrange
-        mbid = "a6a265bf-9f81-4055-8224-f7ac0aa6b937"
+        mbid = "03c91c40-49a6-44a7-90e7-a700edf97a62"
 
         # Act
         album = self.network.get_album_by_mbid(mbid)
@@ -253,7 +253,7 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
 
         # Assert
         assert isinstance(album, pylast.Album)
-        assert album.title.lower() == "test"
+        assert album.title == "Believe"
         assert album_mbid == mbid
 
     def test_artist_mbid(self):


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos