### PR TITLE
Convert setup.py to static setup.cfg and format with setup-cfg-fmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,6 @@ charset = utf-8
 [*.py]
 indent_size = 4
 indent_style = space
-
 trim_trailing_whitespace = true
 
 # Two-space indentation

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,7 +23,6 @@ exclude-labels:
   - "changelog: skip"
 
 template: |
-
   $CHANGES
 
 version-resolver:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,18 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: deploy-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            deploy-
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_release_draft:
-    if: github.repository_owner == 'hugovk'
+    if: github.repository_owner == 'pylast'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next release notes as pull requests are merged into "main"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,21 +24,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{
-            hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.11b1
     hooks:
       - id: black
         args: ["--target-version", "py36"]
@@ -15,19 +15,19 @@ repos:
         types: []
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.11.0
+    rev: v1.12.0
     hooks:
       - id: blacken-docs
         args: ["--target-version", "py36"]
-        additional_dependencies: [black==20.8b1]
+        additional_dependencies: [black==21.11b1]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -42,6 +42,11 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
+
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.20.0
+    hooks:
+      - id: setup-cfg-fmt
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 0.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,52 @@
+[metadata]
+name = pylast
+description = A Python interface to Last.fm and Libre.fm
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/pylast/pylast
+author = Amr Hassan <amr.hassan@gmail.com> and Contributors
+author_email = amr.hassan@gmail.com
+license = Apache-2.0
+license_file = LICENSE.txt
+classifiers =
+    Development Status :: 5 - Production/Stable
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Internet
+    Topic :: Multimedia :: Sound/Audio
+    Topic :: Software Development :: Libraries :: Python Modules
+keywords =
+    Last.fm
+    music
+    scrobble
+    scrobbling
+
+[options]
+packages = find:
+python_requires = >=3.6
+package_dir = =src
+setup_requires =
+    setuptools-scm
+
+[options.packages.find]
+where = src
+
+[options.extras_require]
+tests =
+    flaky
+    pytest
+    pytest-cov
+    pytest-random-order
+    pyyaml
+
 [flake8]
 max_line_length = 88
 

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,12 @@
-from setuptools import find_packages, setup
-
-with open("README.md") as f:
-    long_description = f.read()
+from setuptools import setup
 
 
-def local_scheme(version):
+def local_scheme(version) -> str:
     """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
     to be able to upload to Test PyPI"""
     return ""
 
 
 setup(
-    name="pylast",
-    description="A Python interface to Last.fm and Libre.fm",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Amr Hassan <amr.hassan@gmail.com> and Contributors",
-    author_email="amr.hassan@gmail.com",
-    url="https://github.com/pylast/pylast",
-    license="Apache2",
-    keywords=["Last.fm", "music", "scrobble", "scrobbling"],
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
     use_scm_version={"local_scheme": local_scheme},
-    setup_requires=["setuptools_scm"],
-    extras_require={
-        "tests": ["flaky", "pytest", "pytest-cov", "pytest-random-order", "pyyaml"]
-    },
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "License :: OSI Approved :: Apache Software License",
-        "Topic :: Internet",
-        "Topic :: Multimedia :: Sound/Audio",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ],
 )


### PR DESCRIPTION
Changes proposed in this pull request:

 * Convert setup.py to static setup.cfg with https://github.com/asottile/setup-py-upgrade and format with https://github.com/asottile/setup-cfg-fmt 
 * CI: Use actions/setup-python's pip cache
 * Fix a typo so release drafter runs for this org
