### PR TITLE
Speedup: Use faster `importlib.metadata` for getting version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ long_description_content_type = text/markdown
 url = https://github.com/pylast/pylast
 author = Amr Hassan <amr.hassan@gmail.com> and Contributors
 author_email = amr.hassan@gmail.com
+maintainer = Hugo van Kemenade
 license = Apache-2.0
 license_file = LICENSE.txt
 classifiers =
@@ -31,6 +32,8 @@ keywords =
 
 [options]
 packages = find:
+install_requires =
+    importlib-metadata;python_version < '3.8'
 python_requires = >=3.6
 package_dir = =src
 setup_requires =

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -33,13 +33,18 @@ from http.client import HTTPSConnection
 from urllib.parse import quote_plus
 from xml.dom import Node, minidom
 
-import pkg_resources
+try:
+    # Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # Python 3.7 and lower
+    import importlib_metadata
 
 __author__ = "Amr Hassan, hugovk, Mice Pápai"
 __copyright__ = "Copyright (C) 2008-2010 Amr Hassan, 2013-2021 hugovk, 2017 Mice Pápai"
 __license__ = "apache2"
 __email__ = "amr.hassan@gmail.com"
-__version__ = pkg_resources.get_distribution(__name__).version
+__version__ = importlib_metadata.version(__name__)
 
 
 # 1 : This error does not exist


### PR DESCRIPTION
Changes proposed in this pull request:

 * Importing `pkg_resources` is slow, so instead use `importlib.metadata` (stdlib for 3.8+, and backport for <=3.7
 * For example: 0.519s -> 0.153s

Charts created using:

```sh
python -X importtime -c 'import pylast; print(pylast.__version__)' 2> import.log
tuna import.log
```

# Before

![image](https://user-images.githubusercontent.com/1324225/142769725-20f6cdc3-f168-454e-aaf5-a05617356db2.png)


# After

![image](https://user-images.githubusercontent.com/1324225/142769732-21ea6e5a-c5cc-4a81-8b6f-073bfa3ddaf4.png)

