### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,22 +3,19 @@ repos:
     rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
     rev: 21.11b1
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
-        # override until resolved: https://github.com/psf/black/issues/402
-        files: \.pyi?$
-        types: []
+        args: [--target-version=py37]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.0
     hooks:
       - id: blacken-docs
-        args: ["--target-version", "py36"]
+        args: [--target-version=py37]
         additional_dependencies: [black==21.11b1]
 
   - repo: https://github.com/PyCQA/isort

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-pyLast
-======
+# pyLast
 
 [![PyPI version](https://img.shields.io/pypi/v/pylast.svg)](https://pypi.org/project/pylast/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/pylast.svg)](https://pypi.org/project/pylast/)
@@ -14,8 +13,7 @@ such as [Libre.fm](https://libre.fm/).
 
 Use the pydoc utility for help on usage or see [tests/](tests/) for examples.
 
-Installation
-------------
+## Installation
 
 Install via pip:
 
@@ -32,11 +30,12 @@ python3 -m pip install -U git+https://github.com/pylast/pylast
 Or from requirements.txt:
 
 ```txt
--e git://github.com/pylast/pylast.git#egg=pylast
+-e https://github.com/pylast/pylast.git#egg=pylast
 ```
 
 Note:
 
+* pyLast 5.0+ supports Python 3.7-3.10.
 * pyLast 4.3+ supports Python 3.6-3.10.
 * pyLast 4.0 - 4.2 supports Python 3.6-3.9.
 * pyLast 3.2 - 3.3 supports Python 3.5-3.8.
@@ -48,8 +47,7 @@ Note:
 * pyLast 0.5 supports Python 2, 3.
 * pyLast < 0.5 supports Python 2.
 
-Features
---------
+## Features
 
  * Simple public interface.
  * Access to all the data exposed by the Last.fm web services.
@@ -60,8 +58,7 @@ Features
  * Support for other API-compatible networks like Libre.fm.
 
 
-Getting started
----------------
+## Getting started
 
 Here's some simple code example to get you started. In order to create any object from
 pyLast, you need a `Network` object which represents a social music network that is
@@ -100,8 +97,7 @@ More examples in
 <a href="https://github.com/hugovk/lastfm-tools">hugovk/lastfm-tools</a> and
 [tests/](https://github.com/pylast/pylast/tree/main/tests).
 
-Testing
--------
+## Testing
 
 The [tests/](https://github.com/pylast/pylast/tree/main/tests) directory contains
 integration and unit tests with Last.fm, and plenty of code examples.
@@ -140,8 +136,7 @@ coverage html   # for HTML report
 open htmlcov/index.html
 ```
 
-Logging
--------
+## Logging
 
 To enable from your own code:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -34,7 +33,7 @@ keywords =
 packages = find:
 install_requires =
     importlib-metadata;python_version < '3.8'
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir = =src
 setup_requires =
     setuptools-scm

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{py3, 310, 39, 38, 37, 36}
+    py{py3, 310, 39, 38, 37}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Python 3.6 is EOL next month:

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

And little used. Here's the pip installs for pylast from PyPI for October 2021:

| category | percent | downloads |
|:---------|--------:|----------:|
| 3.9      |  65.55% |    37,605 |
| 3.8      |  23.05% |    13,223 |
| null     |   7.98% |     4,577 |
| 3.7      |   1.78% |     1,021 |
| 3.10     |   0.72% |       414 |
| 3.6      |   0.60% |       342 |
| 2.7      |   0.32% |       183 |
| 3.11     |   0.01% |         3 |
| 3.5      |   0.01% |         3 |
| 3.4      |   0.00% |         1 |
| Total    |         |    57,372 |

Date range: 2021-10-01 - 2021-10-31

Source: `pip install -U pypistats && pypistats python_minor pylast --last-month`