### PR TITLE
Replace http.client with HTTPX

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: blacken-docs
         args: [--target-version=py37]
-        additional_dependencies: [black==21.11b1]
+        additional_dependencies: [black==21.12b0]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ keywords =
 [options]
 packages = find:
 install_requires =
+    httpx
     importlib-metadata;python_version < '3.8'
 python_requires = >=3.7
 package_dir = =src

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -30,9 +30,10 @@ import ssl
 import tempfile
 import time
 import xml.dom
-from http.client import HTTPSConnection
 from urllib.parse import quote_plus
 from xml.dom import Node, minidom
+
+import httpx
 
 try:
     # Python 3.8+
@@ -124,6 +125,12 @@ DELAY_TIME = 0.2
 
 # Python >3.4 has sane defaults
 SSL_CONTEXT = ssl.create_default_context()
+
+HEADERS = {
+    "Content-type": "application/x-www-form-urlencoded",
+    "Accept-Charset": "utf-8",
+    "User-Agent": f"pylast/{__version__}",
+}
 
 logger = logging.getLogger(__name__)
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -390,7 +397,7 @@ class _Network:
     def enable_proxy(self, host, port):
         """Enable a default web proxy"""
 
-        self.proxy = [host, _number(port)]
+        self.proxy = f"{host}:{_number(port)}"
         self.proxy_enabled = True
 
     def disable_proxy(self):
@@ -906,68 +913,41 @@ class _Request:
             self.network._delay_call()
 
         username = self.params.pop("username", None)
-        username = f"?username={username}" if username is not None else ""
-
-        data = []
-        for name in self.params.keys():
-            data.append("=".join((name, quote_plus(_string(self.params[name])))))
-        data = "&".join(data)
-
-        headers = {
-            "Content-type": "application/x-www-form-urlencoded",
-            "Accept-Charset": "utf-8",
-            "User-Agent": "pylast/" + __version__,
-        }
+        username = "" if username is None else f"?username={username}"
 
         (host_name, host_subdir) = self.network.ws_server
 
         if self.network.is_proxy_enabled():
-            conn = HTTPSConnection(
-                context=SSL_CONTEXT,
-                host=self.network._get_proxy()[0],
-                port=self.network._get_proxy()[1],
+            client = httpx.Client(
+                verify=SSL_CONTEXT,
+                base_url=f"https://{host_name}",
+                headers=HEADERS,
+                proxies=f"http://{self.network._get_proxy()}",
+            )
+        else:
+            client = httpx.Client(
+                verify=SSL_CONTEXT,
+                base_url=f"https://{host_name}",
+                headers=HEADERS,
             )
 
-            try:
-                conn.request(
-                    method="POST",
-                    url=f"https://{host_name}{host_subdir}{username}",
-                    body=data,
-                    headers=headers,
-                )
-            except Exception as e:
-                raise NetworkError(self.network, e) from e
-
-        else:
-            conn = HTTPSConnection(context=SSL_CONTEXT, host=host_name)
-
-            try:
-                conn.request(
-                    method="POST",
-                    url=f"{host_subdir}{username}",
-                    body=data,
-                    headers=headers,
-                )
-            except Exception as e:
-                raise NetworkError(self.network, e) from e
-
         try:
-            response = conn.getresponse()
-            if response.status in [500, 502, 503, 504]:
-                raise WSError(
-                    self.network,
-                    response.status,
-                    "Connection to the API failed with HTTP code "
-                    + str(response.status),
-                )
-            response_text = _unicode(response.read())
+            response = client.post(f"{host_subdir}{username}", data=self.params)
         except Exception as e:
-            raise MalformedResponseError(self.network, e) from e
+            raise NetworkError(self.network, e) from e
+
+        if response.status_code in (500, 502, 503, 504):
+            raise WSError(
+                self.network,
+                response.status_code,
+                f"Connection to the API failed with HTTP code {response.status_code}",
+            )
+        response_text = _unicode(response.read())
 
         try:
             self._check_response_for_errors(response_text)
         finally:
-            conn.close()
+            client.close()
         return response_text
 
     def execute(self, cacheable: bool = False) -> xml.dom.minidom.Document:

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1101,7 +1101,7 @@ Image = collections.namedtuple(
 
 def _string_output(func):
     def r(*args):
-        return _string(func(*args))
+        return str(func(*args))
 
     return r
 
@@ -2730,12 +2730,6 @@ def _unicode(text):
         return str(text)
 
 
-def _string(string):
-    if isinstance(string, str):
-        return string
-    return str(string)
-
-
 def cleanup_nodes(doc):
     """
     Remove text nodes containing only whitespace
@@ -2881,7 +2875,7 @@ def _extract_tracks(doc, network):
 def _url_safe(text):
     """Does all kinds of tricks on a text to make it safe to use in a URL."""
 
-    return quote_plus(quote_plus(_string(text))).lower()
+    return quote_plus(quote_plus(str(text))).lower()
 
 
 def _number(string):
@@ -2908,7 +2902,7 @@ def _unescape_htmlentity(string):
 
 
 def _parse_response(response: str) -> xml.dom.minidom.Document:
-    response = _string(response).replace("opensearch:", "")
+    response = str(response).replace("opensearch:", "")
     try:
         doc = minidom.parseString(response)
     except xml.parsers.expat.ExpatError:

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2724,8 +2724,6 @@ def md5(text):
 def _unicode(text):
     if isinstance(text, bytes):
         return str(text, "utf-8")
-    elif isinstance(text, str):
-        return text
     else:
         return str(text)
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -296,13 +296,12 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
 
     def test_proxy(self):
         # Arrange
-        host = "example.com"
-        port = 1234
+        proxy = "http://example.com:1234"
 
         # Act / Assert
-        self.network.enable_proxy(host, port)
+        self.network.enable_proxy(proxy)
         assert self.network.is_proxy_enabled()
-        assert self.network._get_proxy() == "example.com:1234"
+        assert self.network.proxy == "http://example.com:1234"
 
         self.network.disable_proxy()
         assert not self.network.is_proxy_enabled()

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Integration (not unit) tests for pylast.py
 """
@@ -297,13 +296,13 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
 
     def test_proxy(self):
         # Arrange
-        host = "https://example.com"
+        host = "example.com"
         port = 1234
 
         # Act / Assert
         self.network.enable_proxy(host, port)
         assert self.network.is_proxy_enabled()
-        assert self.network._get_proxy() == ["https://example.com", 1234]
+        assert self.network._get_proxy() == "example.com:1234"
 
         self.network.disable_proxy()
         assert not self.network.is_proxy_enabled()


### PR DESCRIPTION
Fixes #361.

Changes proposed in this pull request:

 * Minimal changes to switch to HTTPX
 * Further improvements welcome in the future
 * Switching to HTTPX means there's scope for breaking changes (for example, some underlying networking exceptions have changed) so now is a good time to switch because Python 3.6 is being dropped (https://github.com/pylast/pylast/pull/378) and will warrant a major bump
