### PR TITLE
Strip invalid XML characters from response

### DIFF
--- a/tests/unicode_test.py
+++ b/tests/unicode_test.py
@@ -27,3 +27,42 @@ def test_get_cache_key(artist):
 def test_cast_and_hash(obj):
     assert type(str(obj)) is str
     assert isinstance(hash(obj), int)
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        (
+            # Plain text
+            '<album mbid="">test album name</album>',
+            '<album mbid="">test album name</album>',
+        ),
+        (
+            # Contains Unicode ENQ Enquiry control character
+            '<album mbid="">test album \u0005name</album>',
+            '<album mbid="">test album name</album>',
+        ),
+    ],
+)
+def test__remove_invalid_xml_chars(test_input: str, expected: str) -> None:
+    assert pylast._remove_invalid_xml_chars(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        (
+            # Plain text
+            '<album mbid="">test album name</album>',
+            '<?xml version="1.0" ?><album mbid="">test album name</album>',
+        ),
+        (
+            # Contains Unicode ENQ Enquiry control character
+            '<album mbid="">test album \u0005name</album>',
+            '<?xml version="1.0" ?><album mbid="">test album name</album>',
+        ),
+    ],
+)
+def test__parse_response(test_input: str, expected: str) -> None:
+    doc = pylast._parse_response(test_input)
+    assert doc.toxml() == expected


### PR DESCRIPTION
Fixes https://github.com/pylast/pylast/issues/381

Changes proposed in this pull request:

 * In rare cases (I've seen it only once) a Last.fm response can contain invalid XML characters, such as a control character
 * For performance, let's only strip them out when the XML parser raises an exception, and then try parsing again
 * See also https://stackoverflow.com/a/62099920/724176

