### PR TITLE
Restore support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     rev: v2.31.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py36-plus]
 
   - repo: https://github.com/psf/black
     rev: 21.12b0
     hooks:
       - id: black
-        args: [--target-version=py37]
+        args: [--target-version=py36]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.0
     hooks:
       - id: blacken-docs
-        args: [--target-version=py37]
+        args: [--target-version=py36]
         additional_dependencies: [black==21.11b1]
 
   - repo: https://github.com/PyCQA/isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -33,7 +34,7 @@ keywords =
 packages = find:
 install_requires =
     importlib-metadata;python_version < '3.8'
-python_requires = >=3.7
+python_requires = >=3.6
 package_dir = =src
 setup_requires =
     setuptools-scm

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{py3, 310, 39, 38, 37}
+    py{py3, 310, 39, 38, 37, 36}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Changes proposed in this pull request:

 * Temporarily undo https://github.com/pylast/pylast/pull/378 to make a release with some deprecations
 * The deprecations can then be removed at the same time as dropping 3.6

