### PR TITLE
Deprecate is_streamable and is_fulltrack_available

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
+
+xfail_strict=true

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -29,6 +29,7 @@ import shelve
 import ssl
 import tempfile
 import time
+import warnings
 import xml.dom
 from http.client import HTTPSConnection
 from urllib.parse import quote_plus
@@ -1783,13 +1784,18 @@ class Artist(_Taggable):
             return self.listener_count
 
     def is_streamable(self):
-        """Returns True if the artist is streamable."""
-
-        return bool(
-            _number(
-                _extract(self._request(self.ws_prefix + ".getInfo", True), "streamable")
-            )
+        """Returns True if the artist is streamable: always False because Last.fm has
+        deprecated the Radio API."""
+        warnings.warn(
+            "Always returns False. Last.fm has deprecated the Radio API and will "
+            "it at some point. is_streamable() will be removed in pylast 5.0.0. "
+            "See https://www.last.fm/api/radio and "
+            "https://support.last.fm/t/"
+            "is-the-streamable-attribute-broken-it-always-returns-0/39723/3",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return False
 
     def get_bio(self, section, language=None):
         """
@@ -2130,18 +2136,32 @@ class Track(_Opus):
         return bool(loved)
 
     def is_streamable(self):
-        """Returns True if the track is available at Last.fm."""
-
-        doc = self._request(self.ws_prefix + ".getInfo", True)
-        return _extract(doc, "streamable") == "1"
+        """Returns True if the artist is streamable: always False because Last.fm has
+        deprecated the Radio API."""
+        warnings.warn(
+            "Always returns False. Last.fm has deprecated the Radio API and will "
+            "it at some point. is_streamable() will be removed in pylast 5.0.0. "
+            "See https://www.last.fm/api/radio and "
+            "https://support.last.fm/t/"
+            "is-the-streamable-attribute-broken-it-always-returns-0/39723/3",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return False
 
     def is_fulltrack_available(self):
-        """Returns True if the full track is available for streaming."""
-
-        doc = self._request(self.ws_prefix + ".getInfo", True)
-        return (
-            doc.getElementsByTagName("streamable")[0].getAttribute("fulltrack") == "1"
+        """Returns True if the full track is available for streaming: always False
+        because Last.fm has deprecated the Radio API."""
+        warnings.warn(
+            "Always returns False. Last.fm has deprecated the Radio API and will "
+            "remove it at some point. is_fulltrack_available() will be removed in "
+            "pylast 5.0.0. See https://www.last.fm/api/radio and "
+            "https://support.last.fm/t/"
+            "is-the-streamable-attribute-broken-it-always-returns-0/39723/3",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return False
 
     def get_album(self):
         """Returns the album object of this track."""

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -268,7 +268,6 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         # Assert
         assert corrected_artist_name == "Guns N' Roses"
 
-    @pytest.mark.xfail
     def test_get_userplaycount(self):
         # Arrange
         artist = pylast.Artist("John Lennon", self.network, username=self.username)
@@ -277,4 +276,4 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         playcount = artist.get_userplaycount()
 
         # Assert
-        assert playcount >= 0  # whilst xfail: # pragma: no cover
+        assert playcount >= 0

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -229,7 +229,8 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         mbid = artist1.get_mbid()
 
         playcount = artist1.get_playcount()
-        streamable = artist1.is_streamable()
+        with pytest.warns(DeprecationWarning):
+            streamable = artist1.is_streamable()
         name = artist1.get_name(properly_capitalized=False)
         name_cap = artist1.get_name(properly_capitalized=True)
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -267,8 +267,6 @@ class TestPyLastNetwork(TestPyLastWithLastFm):
         assert isinstance(artist, pylast.Artist)
         assert artist.name in ("MusicBrainz Test Artist", "MusicBrainzz Test Artist")
 
-    @pytest.mark.xfail(reason="Broken at Last.fm: Track not found")
-    # https://support.last.fm/t/track-getinfo-with-mbid-returns-6-track-not-found/47905
     def test_track_mbid(self):
         # Arrange
         mbid = "ebc037b1-cc9c-44f2-a21f-83c219f0e1e0"

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -123,7 +123,8 @@ class TestPyLastTrack(TestPyLastWithLastFm):
         track = pylast.Track("Nirvana", "Lithium", self.network)
 
         # Act
-        streamable = track.is_streamable()
+        with pytest.warns(DeprecationWarning):
+            streamable = track.is_streamable()
 
         # Assert
         assert not streamable
@@ -133,7 +134,8 @@ class TestPyLastTrack(TestPyLastWithLastFm):
         track = pylast.Track("Nirvana", "Lithium", self.network)
 
         # Act
-        fulltrack_available = track.is_fulltrack_available()
+        with pytest.warns(DeprecationWarning):
+            fulltrack_available = track.is_fulltrack_available()
 
         # Assert
         assert not fulltrack_available


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

 * Last.fm has deprecated the Radio API and the `streamable` attribute is also deprecated and will be removed at some point
 * https://www.last.fm/api/radio
 * https://support.last.fm/t/is-the-streamable-attribute-broken-it-always-returns-0/39723/3
 * Let's `return False` from both `is_streamable()` and the `is_fulltrack_available()`, and deprecate them
 * They will be removed in the upcoming pylast 5.0.0

Also:

 * A couple of `xfail`s now pass, remove them and set `xfail_strict=true` so we're notified when others start passing
