### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     rev: v2.31.0
     hooks:
       - id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
     rev: 21.12b0
     hooks:
       - id: black
-        args: [--target-version=py36]
+        args: [--target-version=py37]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.0
     hooks:
       - id: blacken-docs
-        args: [--target-version=py36]
+        args: [--target-version=py37]
         additional_dependencies: [black==21.11b1]
 
   - repo: https://github.com/PyCQA/isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -34,7 +33,7 @@ keywords =
 packages = find:
 install_requires =
     importlib-metadata;python_version < '3.8'
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir = =src
 setup_requires =
     setuptools-scm

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{py3, 310, 39, 38, 37, 36}
+    py{py3, 310, 39, 38, 37}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Reverts pylast/pylast#383, redo https://github.com/pylast/pylast/pull/378.

Python 3.6 is EOL:

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

And little used. Here's the pip installs for pylast from PyPI for December 2021:

| category | percent | downloads |
|:---------|--------:|----------:|
| 3.9      |  70.86% |    39,956 |
| 3.8      |  22.68% |    12,786 |
| null     |   2.22% |     1,253 |
| 3.7      |   2.07% |     1,170 |
| 3.10     |   1.36% |       766 |
| 3.6      |   0.59% |       335 |
| 2.7      |   0.18% |       100 |
| 3.11     |   0.03% |        18 |
| 3.5      |   0.00% |         2 |
| Total    |         |    56,386 |

Date range: 2021-12-01 - 2021-12-31

Source: `pip install -U pypistats && pypistats python_minor pylast --last-month`