### PR TITLE
Remove deprecated `is_streamable` and `is_fulltrack_available`

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -29,7 +29,6 @@ import shelve
 import ssl
 import tempfile
 import time
-import warnings
 import xml.dom
 from http.client import HTTPSConnection
 from urllib.parse import quote_plus
@@ -1783,20 +1782,6 @@ class Artist(_Taggable):
             )
             return self.listener_count
 
-    def is_streamable(self):
-        """Returns True if the artist is streamable: always False because Last.fm has
-        deprecated the Radio API."""
-        warnings.warn(
-            "Always returns False. Last.fm has deprecated the Radio API and will "
-            "it at some point. is_streamable() will be removed in pylast 5.0.0. "
-            "See https://www.last.fm/api/radio and "
-            "https://support.last.fm/t/"
-            "is-the-streamable-attribute-broken-it-always-returns-0/39723/3",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return False
-
     def get_bio(self, section, language=None):
         """
         Returns a section of the bio.
@@ -2134,34 +2119,6 @@ class Track(_Opus):
         doc = self._request(self.ws_prefix + ".getInfo", True, params)
         loved = _number(_extract(doc, "userloved"))
         return bool(loved)
-
-    def is_streamable(self):
-        """Returns True if the artist is streamable: always False because Last.fm has
-        deprecated the Radio API."""
-        warnings.warn(
-            "Always returns False. Last.fm has deprecated the Radio API and will "
-            "it at some point. is_streamable() will be removed in pylast 5.0.0. "
-            "See https://www.last.fm/api/radio and "
-            "https://support.last.fm/t/"
-            "is-the-streamable-attribute-broken-it-always-returns-0/39723/3",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return False
-
-    def is_fulltrack_available(self):
-        """Returns True if the full track is available for streaming: always False
-        because Last.fm has deprecated the Radio API."""
-        warnings.warn(
-            "Always returns False. Last.fm has deprecated the Radio API and will "
-            "remove it at some point. is_fulltrack_available() will be removed in "
-            "pylast 5.0.0. See https://www.last.fm/api/radio and "
-            "https://support.last.fm/t/"
-            "is-the-streamable-attribute-broken-it-always-returns-0/39723/3",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return False
 
     def get_album(self):
         """Returns the album object of this track."""

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -229,8 +229,6 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         mbid = artist1.get_mbid()
 
         playcount = artist1.get_playcount()
-        with pytest.warns(DeprecationWarning):
-            streamable = artist1.is_streamable()
         name = artist1.get_name(properly_capitalized=False)
         name_cap = artist1.get_name(properly_capitalized=True)
 
@@ -240,7 +238,6 @@ class TestPyLastArtist(TestPyLastWithLastFm):
         assert name.lower() == name_cap.lower()
         assert url == "https://www.last.fm/music/radiohead"
         assert mbid == "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-        assert isinstance(streamable, bool)
 
     def test_artist_eq_none_is_false(self):
         # Arrange

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -118,28 +118,6 @@ class TestPyLastTrack(TestPyLastWithLastFm):
         # Assert
         assert duration >= 200000
 
-    def test_track_is_streamable(self):
-        # Arrange
-        track = pylast.Track("Nirvana", "Lithium", self.network)
-
-        # Act
-        with pytest.warns(DeprecationWarning):
-            streamable = track.is_streamable()
-
-        # Assert
-        assert not streamable
-
-    def test_track_is_fulltrack_available(self):
-        # Arrange
-        track = pylast.Track("Nirvana", "Lithium", self.network)
-
-        # Act
-        with pytest.warns(DeprecationWarning):
-            fulltrack_available = track.is_fulltrack_available()
-
-        # Assert
-        assert not fulltrack_available
-
     def test_track_get_album(self):
         # Arrange
         track = pylast.Track("Nirvana", "Lithium", self.network)


### PR DESCRIPTION
Changes proposed in this pull request:

 * Remove methods deprecated in [#384](https://github.com/pylast/pylast/pull/384)
 * Last.fm has [deprecated the Radio API](https://www.last.fm/api/radio) and [the `streamable` attribute is also deprecated and will be removed at some point](https://support.last.fm/t/is-the-streamable-attribute-broken-it-always-returns-0/39723/3)