### PR TITLE
If album has no MBID, album.get_getmbid() returns None

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -18,7 +18,6 @@
 # limitations under the License.
 #
 # https://github.com/pylast/pylast
-
 from __future__ import annotations
 
 import collections
@@ -1595,7 +1594,7 @@ class _Opus(_Taggable):
             )
         )
 
-    def get_mbid(self):
+    def get_mbid(self) -> str | None:
         """Returns the MusicBrainz ID of the album or track."""
 
         doc = self._request(self.ws_prefix + ".getInfo", cacheable=True)
@@ -1604,7 +1603,7 @@ class _Opus(_Taggable):
             lfm = doc.getElementsByTagName("lfm")[0]
             opus = next(self._get_children_by_tag_name(lfm, self.ws_prefix))
             mbid = next(self._get_children_by_tag_name(opus, "mbid"))
-            return mbid.firstChild.nodeValue
+            return mbid.firstChild.nodeValue if mbid.firstChild else None
         except StopIteration:
             return None
 

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -96,3 +96,23 @@ class TestPyLastAlbum(TestPyLastWithLastFm):
         # Assert
         self.assert_startswith(image, "https://")
         self.assert_endswith(image, ".gif")
+
+    def test_mbid(self):
+        # Arrange
+        album = self.network.get_album("Radiohead", "OK Computer")
+
+        # Act
+        mbid = album.get_mbid()
+
+        # Assert
+        assert mbid == "0b6b4ba0-d36f-47bd-b4ea-6a5b91842d29"
+
+    def test_no_mbid(self):
+        # Arrange
+        album = self.network.get_album("Test Artist", "Test Album")
+
+        # Act
+        mbid = album.get_mbid()
+
+        # Assert
+        assert mbid is None


### PR DESCRIPTION
Fixes #389

Changes proposed in this pull request:

 * If an album has no MBID (the `album.getinfo` XML has `<mbid/>` instead of something like `<mbid>0b6b4ba0-d36f-47bd-b4ea-6a5b91842d29</mbid>`), then return `None` instead of raising an `AttributeError`
