### PR TITLE
Output coverage XML for Codecov to upload

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv =
 extras =
     tests
 commands =
-    pytest -v -s -W all --cov pylast --cov tests --cov-report term-missing --random-order {posargs}
+    pytest -v -s -W all --cov pylast --cov tests --cov-report term-missing --cov-report xml --random-order {posargs}
 
 [testenv:lint]
 passenv =


### PR DESCRIPTION
Coverage has been missing from Codecov for a while.

Before:

```
[2022-02-27T14:35:10.483Z] ['info'] Searching for coverage files...
[2022-02-27T14:35:10.513Z] ['info'] Warning: Some files located via search were excluded from upload.
[2022-02-27T14:35:10.513Z] ['info'] If Codecov did not locate your files, please review [docs.codecov.com/docs/supported-report-formats](https://docs.codecov.com/docs/supported-report-formats)
[2022-02-27T14:35:10.513Z] ['error'] There was an error running the uploader: No coverage files located, please try use `-f`, or change the project root with `-R`
```

After:

```
[2022-02-27T14:39:45.682Z] ['info'] => Found 1 possible coverage files:
  coverage.xml
[2022-02-27T14:39:45.682Z] ['info'] Processing /home/runner/work/pylast/pylast/coverage.xml...
```