### PR TITLE
Log method names at INFO level, also log API return data at DEBUG level

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ To enable from your own code:
 import logging
 import pylast
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
+
 
 network = pylast.LastFMNetwork(...)
 ```
@@ -152,5 +153,8 @@ network = pylast.LastFMNetwork(...)
 To enable from pytest:
 
 ```sh
-pytest --log-cli-level debug -k test_album_search_images
+pytest --log-cli-level info -k test_album_search_images
 ```
+
+To also see data returned from the API, use `level=logging.DEBUG` or
+`--log-cli-level debug` instead.

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -822,7 +822,7 @@ class _Request:
     """Representing an abstract web service operation."""
 
     def __init__(self, network, method_name, params=None):
-        logger.debug(method_name)
+        logger.info(method_name)
 
         if params is None:
             params = {}
@@ -962,7 +962,7 @@ class _Request:
             raise MalformedResponseError(self.network, e) from e
 
         e = doc.getElementsByTagName("lfm")[0]
-        # logger.debug(doc.toprettyxml())
+        logger.debug(doc.toprettyxml())
 
         if e.getAttribute("status") != "ok":
             e = doc.getElementsByTagName("error")[0]


### PR DESCRIPTION
Changes proposed in this pull request:

 * Log method names at `INFO` level instead of `DEBUG`: "Confirmation that things are working as expected"
 * Also log API return data at `DEBUG` level: "Detailed information, typically of interest only when diagnosing problems"
 * https://docs.python.org/3/howto/logging.html#when-to-use-logging
