### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     if: github.repository_owner == 'pylast'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
-          cache-dependency-path: "setup.py"
+          cache-dependency-path: setup.cfg
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -1,0 +1,18 @@
+name: Require PR label
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: minimum
+          count: 1
+          labels:
+            "changelog: Added, changelog: Changed, changelog: Deprecated, changelog:
+            Fixed, changelog: Removed, changelog: Security, changelog: skip"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-20.04]
-        include:
-          # Include new variables for Codecov
-          - { codecov-flag: GHA_Ubuntu2004, os: ubuntu-20.04 }
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +22,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: "setup.py"
+          cache-dependency-path: setup.cfg
 
       - name: Install dependencies
         run: |
@@ -45,5 +42,5 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v2
         with:
-          flags: ${{ matrix.codecov-flag }}
+          flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,11 @@ jobs:
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+
+  success:
+    needs: test
+    runs-on: ubuntu-latest
+    name: test successful
+    steps:
+      - name: Success
+        run: echo Test successful

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -35,7 +35,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -44,6 +44,7 @@ repos:
     rev: v1.20.1
     hooks:
       - id: setup-cfg-fmt
+        args: [--max-py-version=3.11]
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 0.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Internet

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-def local_scheme(version) -> str:
+def local_scheme(version: str) -> str:
     """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
     to be able to upload to Test PyPI"""
     return ""

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -110,13 +110,13 @@ class TestPyLastTrack(TestPyLastWithLastFm):
 
     def test_track_get_duration(self) -> None:
         # Arrange
-        track = pylast.Track("Cher", "Believe", self.network)
+        track = pylast.Track("Radiohead", "Creep", self.network)
 
         # Act
         duration = track.get_duration()
 
         # Assert
-        assert duration >= 200000
+        assert duration >= 100000
 
     def test_track_get_album(self) -> None:
         # Arrange

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{py3, 310, 39, 38, 37}
+    py{py3, 311, 310, 39, 38, 37}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Fixes #


Python 3.11 beta is out on Friday with full release in October:

* 3.11.0 beta 1: Friday, 2022-05-06
* 3.11.0 final: Monday, 2022-10-03

https://peps.python.org/pep-0664/

Changes proposed in this pull request:

 * Test `3.11-dev` on GitHub Actions
 * Add `py311` to `tox.ini`
 * Add Trove classifier
 * Update some config

