### PR TITLE
Add `network_via_web_auth` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,9 @@ import pylast
 API_KEY = "b25b959554ed76058ac220b7b2e0a026"  # this is a sample key
 API_SECRET = "425b55975eed76058ac220b7b4e8a054"
 
-# In order to perform a write operation you need to authenticate yourself
-username = "your_user_name"
-password_hash = pylast.md5("your_password")
-
-network = pylast.LastFMNetwork(
+network = pylast.network_via_web_auth(
     api_key=API_KEY,
     api_secret=API_SECRET,
-    username=username,
-    password_hash=password_hash,
 )
 
 # Now you can use that object everywhere


### PR DESCRIPTION
Fixes #407.

Changes proposed in this pull request:

 * Add a helper to create a network object and open the browser to authenticate via web auth
 * Save the session key to `~/.session_key` and read next time
 * Re: https://github.com/pylast/pylast/issues/407#issuecomment-1164053561
