### PR TITLE
Fix test_track_get_duration

### DIFF
--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Integration (not unit) tests for pylast.py
 """
@@ -110,7 +109,7 @@ class TestPyLastTrack(TestPyLastWithLastFm):
 
     def test_track_get_duration(self) -> None:
         # Arrange
-        track = pylast.Track("Radiohead", "Creep", self.network)
+        track = pylast.Track("Daft Punk", "Something About Us", self.network)
 
         # Act
         duration = track.get_duration()


### PR DESCRIPTION
Changes proposed in this pull request:

 * Workaround Last.fm bug where some tracks are returning `"duration": "0"`
 * Discussed further at https://support.last.fm/t/missing-track-lengths-on-various-songs/57615/22?u=hvk
 * Looks like they manually fixed this Daft Punk track after it was reported in that thread, let's switch over
