### PR TITLE
Test on Python 3.11 final

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Changes proposed in this pull request:

 * Python 3.11.0 final was [released yesterday](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 
 * Let's switch `3.11-dev` to `3.11` for GitHub Actions 
