### PR TITLE
Add type annotations to methods that take timestamp parameter

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -32,7 +32,6 @@ import ssl
 import tempfile
 import time
 import xml.dom
-from typing import Optional
 from urllib.parse import quote_plus
 from xml.dom import Node, minidom
 

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2307,7 +2307,7 @@ class User(_Chartable):
         Parameters:
         limit : If None, it will try to pull all the available data.
         from (Optional) : Beginning timestamp of a range - only display
-        scrobbles after this time, in UNIX timestamp format (integer
+        scrobbles after this time, in Unix timestamp format (integer
         number of seconds since 00:00:00, January 1st 1970 UTC).
         to (Optional) : End timestamp of a range - only display scrobbles
         before this time, in Unix timestamp format (integer number of

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -31,6 +31,7 @@ import shelve
 import ssl
 import tempfile
 import time
+from typing import Optional
 import xml.dom
 from urllib.parse import quote_plus
 from xml.dom import Node, minidom
@@ -529,16 +530,16 @@ class _Network:
 
     def scrobble(
         self,
-        artist,
-        title,
-        timestamp,
-        album=None,
-        album_artist=None,
-        track_number=None,
-        duration=None,
-        stream_id=None,
-        context=None,
-        mbid=None,
+        artist: str,
+        title: str,
+        timestamp: int,
+        album: Optional[str] = None,
+        album_artist: Optional[str] = None,
+        track_number: Optional[int] = None,
+        duration: Optional[int] = None,
+        stream_id: Optional[str] = None,
+        context: Optional[str] = None,
+        mbid: Optional[str] = None,
     ):
         """Used to add a track-play to a user's profile.
 
@@ -547,7 +548,7 @@ class _Network:
             title (Required) : The track name.
             timestamp (Required) : The time the track started playing, in UNIX
                 timestamp format (integer number of seconds since 00:00:00,
-                January 1st 1970 UTC). This must be in the UTC time zone.
+                January 1st 1970 UTC).
             album (Optional) : The album name.
             album_artist (Optional) : The album artist - if this differs from
                 the track artist.
@@ -2295,8 +2296,8 @@ class User(_Chartable):
         self,
         limit: int = 10,
         cacheable: bool = True,
-        time_from=None,
-        time_to=None,
+        time_from: Optional[int] = None,
+        time_to: Optional[int] = None,
         stream: bool = False,
         now_playing: bool = False,
     ):
@@ -2308,12 +2309,10 @@ class User(_Chartable):
         limit : If None, it will try to pull all the available data.
         from (Optional) : Beginning timestamp of a range - only display
         scrobbles after this time, in UNIX timestamp format (integer
-        number of seconds since 00:00:00, January 1st 1970 UTC). This
-        must be in the UTC time zone.
+        number of seconds since 00:00:00, January 1st 1970 UTC).
         to (Optional) : End timestamp of a range - only display scrobbles
         before this time, in UNIX timestamp format (integer number of
-        seconds since 00:00:00, January 1st 1970 UTC). This must be in
-        the UTC time zone.
+        seconds since 00:00:00, January 1st 1970 UTC).
         stream: If True, it will yield tracks as soon as a page has been retrieved.
 
         This method uses caching. Enable caching only if you're pulling a

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2380,7 +2380,7 @@ class User(_Chartable):
         return _extract(doc, "registered")
 
     def get_unixtime_registered(self):
-        """Returns the user's registration date as a UNIX timestamp."""
+        """Returns the user's registration date as a Unix timestamp."""
 
         doc = self._request(self.ws_prefix + ".getInfo", True)
 

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -31,8 +31,8 @@ import shelve
 import ssl
 import tempfile
 import time
-from typing import Optional
 import xml.dom
+from typing import Optional
 from urllib.parse import quote_plus
 from xml.dom import Node, minidom
 
@@ -533,13 +533,13 @@ class _Network:
         artist: str,
         title: str,
         timestamp: int,
-        album: Optional[str] = None,
-        album_artist: Optional[str] = None,
-        track_number: Optional[int] = None,
-        duration: Optional[int] = None,
-        stream_id: Optional[str] = None,
-        context: Optional[str] = None,
-        mbid: Optional[str] = None,
+        album: str | None = None,
+        album_artist: str | None = None,
+        track_number: int | None = None,
+        duration: int | None = None,
+        stream_id: str | None = None,
+        context: str | None = None,
+        mbid: str | None = None,
     ):
         """Used to add a track-play to a user's profile.
 
@@ -2296,8 +2296,8 @@ class User(_Chartable):
         self,
         limit: int = 10,
         cacheable: bool = True,
-        time_from: Optional[int] = None,
-        time_to: Optional[int] = None,
+        time_from: int | None = None,
+        time_to: int | None = None,
         stream: bool = False,
         now_playing: bool = False,
     ):

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2310,7 +2310,7 @@ class User(_Chartable):
         scrobbles after this time, in UNIX timestamp format (integer
         number of seconds since 00:00:00, January 1st 1970 UTC).
         to (Optional) : End timestamp of a range - only display scrobbles
-        before this time, in UNIX timestamp format (integer number of
+        before this time, in Unix timestamp format (integer number of
         seconds since 00:00:00, January 1st 1970 UTC).
         stream: If True, it will yield tracks as soon as a page has been retrieved.
 

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -545,7 +545,7 @@ class _Network:
         Parameters:
             artist (Required) : The artist name.
             title (Required) : The track name.
-            timestamp (Required) : The time the track started playing, in UNIX
+            timestamp (Required) : The time the track started playing, in Unix
                 timestamp format (integer number of seconds since 00:00:00,
                 January 1st 1970 UTC).
             album (Optional) : The album name.


### PR DESCRIPTION
This PR is aimed to prevent the possible misuse of UTC timestamp parameters by providing a type hint.
Even though the docstrings say that timestamps should be the "integer number of seconds", it is still quite tempting to expect that a method call like this one will produce a sensible result:

```python
ts = datetime(2021, 10, 19, 10, 1).timestamp() # Returns number of seconds, but as a float with zero fractional part.

lastfm_user.get_recent_tracks(time_from=ts)
```

However, pylast will translate this value into `?from=1634680860.0` (note the trailing 0), which LastFM API simply ignores and treats as missing. As a results, no filtering by scrobble date is applied.

Changes proposed in this pull request:

 * UNIX timestamp parameters are required to have the type of `int` or `Optional[int]`. 
 * Type hints are also added to other parameters of `scrobble` and `get_recent_tracks` methods for consistency.
 * `This must be in the UTC time zone` line  is removed from docstrings, as UNIX timestamp is [timezone-independent by definition](https://stackoverflow.com/a/23062640). 
