### PR TITLE
Double read timeout to fix 'The read operation timed out'

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -894,6 +894,7 @@ class _Request:
         username = "" if username is None else f"?username={username}"
 
         (host_name, host_subdir) = self.network.ws_server
+        timeout = httpx.Timeout(5, read=10)
 
         if self.network.is_proxy_enabled():
             client = httpx.Client(
@@ -901,12 +902,14 @@ class _Request:
                 base_url=f"https://{host_name}",
                 headers=HEADERS,
                 proxies=self.network.proxy,
+                timeout=timeout,
             )
         else:
             client = httpx.Client(
                 verify=SSL_CONTEXT,
                 base_url=f"https://{host_name}",
                 headers=HEADERS,
+                timeout=timeout,
             )
 
         try:


### PR DESCRIPTION
We've been getting lots of errors on the CI, for example https://github.com/pylast/pylast/actions/runs/7532231359:

```
======== 81 passed, 9 skipped, 1 xfailed, 50 errors in 84.73s (0:01:24) ========
```

```pytb
pylast.NetworkError: NetworkError: The read operation timed out
```

Coming from:
```pytb
httpx.ReadTimeout: The read operation timed out
```

Coming from:
```pytb
httpcore.ReadTimeout: The read operation timed out
```

Coming from:
```pytb
 = <ssl.SSLSocket [closed] fd=-1, family=30, type=1, proto=0>, len = 65536, buffer = None

    def read(self, len=1024, buffer=None):
        """Read up to LEN bytes and return them.
        Return zero-length string on EOF."""

        self._checkClosed()
        if self._sslobj is None:
            raise ValueError("Read on closed or unwrapped SSL socket.")
        try:
            if buffer is not None:
                return self._sslobj.read(len, buffer)
            else:
>               return self._sslobj.read(len)
E               TimeoutError: The read operation timed out
```

We can work around this by doubling the default read timeout from 5s to 10s.

I've not so far seen this happen in my normal use of pylast, so perhaps this should only be changed when running tests?