### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,5 @@ target/
 # JetBrains
 .idea/
 
-# Clone Digger
-output.html
+# hatch-vcs
+src/*/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
 
@@ -33,7 +33,7 @@ repos:
         exclude: .github/(ISSUE_TEMPLATE|PULL_REQUEST_TEMPLATE).md
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.6
+    rev: 0.29.2
     hooks:
       - id: check-github-workflows
       - id: check-renovate
@@ -44,22 +44,22 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.1.3
+    rev: 2.2.3
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.18
+    rev: v0.19
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.3.1
+    rev: 1.3.2
     hooks:
       - id: tox-ini-fmt
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ urls.Source = "https://github.com/pylast/pylast"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/pylast/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,8 @@ keywords = [
   "scrobbling",
 ]
 license = { text = "Apache-2.0" }
-maintainers = [
-  { name = "Hugo van Kemenade" },
-]
-authors = [
-  { name = "Amr Hassan <amr.hassan@gmail.com> and Contributors", email = "amr.hassan@gmail.com" },
-]
+maintainers = [ { name = "Hugo van Kemenade" } ]
+authors = [ { name = "Amr Hassan <amr.hassan@gmail.com> and Contributors", email = "amr.hassan@gmail.com" } ]
 requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -39,9 +35,7 @@ classifiers = [
   "Topic :: Multimedia :: Sound/Audio",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dynamic = [
-  "version",
-]
+dynamic = [ "version" ]
 dependencies = [
   "httpx",
 ]
@@ -71,6 +65,7 @@ lint.select = [
   "EM",     # flake8-errmsg
   "F",      # pyflakes errors
   "I",      # isort
+  "ICN",    # flake8-import-conventions
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
   "PGH",    # pygrep-hooks
@@ -80,18 +75,16 @@ lint.select = [
   "W",      # pycodestyle warnings
   "YTT",    # flake8-2020
 ]
-lint.extend-ignore = [
+lint.ignore = [
   "E203", # Whitespace before ':'
   "E221", # Multiple spaces before operator
   "E226", # Missing whitespace around arithmetic operator
   "E241", # Multiple spaces after ','
 ]
-lint.isort.known-first-party = [
-  "pylast",
-]
-lint.isort.required-imports = [
-  "from __future__ import annotations",
-]
+lint.flake8-import-conventions.aliases.datetime = "dt"
+lint.flake8-import-conventions.banned-from = [ "datetime" ]
+lint.isort.known-first-party = [ "pylast" ]
+lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.13"

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import collections
 import hashlib
 import html.entities
-import importlib.metadata
 import logging
 import os
 import re
@@ -37,11 +36,12 @@ from xml.dom import Node, minidom
 
 import httpx
 
+from ._version import __version__
+
 __author__ = "Amr Hassan, hugovk, Mice Pápai"
 __copyright__ = "Copyright (C) 2008-2010 Amr Hassan, 2013-2021 hugovk, 2017 Mice Pápai"
 __license__ = "apache2"
 __email__ = "amr.hassan@gmail.com"
-__version__ = importlib.metadata.version(__name__)
 
 
 # 1 : This error does not exist


### PR DESCRIPTION
Like https://github.com/hugovk/tinytext/pull/195.

With Python 3.13.0rc2:

```sh
python -X importtime -c "import pylast" 2> import.log && tuna import.log
```

# `main`

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/d3b95572-74f2-4927-a1d7-f7f358591dca">

# PR

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/91fe7a6b-1f66-4e36-8b09-05a4c629a5fc">



---

httpx remains the slowest import, but it's very likely it is needed when running pylast. We could replace it with something faster to import like urllib3, but that's for another time.

```console
❯ hyperfine --warmup 32  'python3 -c "import httpx"' 'python3 -c "import urllib3"'
Benchmark 1: python3 -c "import httpx"
  Time (mean ± σ):     146.8 ms ± 114.8 ms    [User: 104.7 ms, System: 18.3 ms]
  Range (min … max):   119.2 ms … 685.5 ms    24 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: python3 -c "import urllib3"
  Time (mean ± σ):      47.8 ms ±   1.5 ms    [User: 38.9 ms, System: 7.8 ms]
  Range (min … max):    46.5 ms …  56.7 ms    60 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  python3 -c "import urllib3" ran
    3.07 ± 2.41 times faster than python3 -c "import httpx"
```

urllib3 also has no dependencies (httpx has 7) and is a bit smaller (13 MB) than httpx (16 MB), so is a bit quicker to install:

<details>
<summary>Details</summary>

```console
❯ python -m venv urllib3

❯ time urllib3/bin/pip install urllib3 --no-cache-dir
Collecting urllib3
  Downloading urllib3-2.2.2-py3-none-any.whl.metadata (6.4 kB)
Downloading urllib3-2.2.2-py3-none-any.whl (121 kB)
Installing collected packages: urllib3
Successfully installed urllib3-2.2.2
urllib3/bin/pip install urllib3 --no-cache-dir  0.28s user 0.10s system 38% cpu 0.980 total

❯ du -sh urllib3
 13Murllib3

❯ python -m venv httpx
Found existing alias for "python". You should use: "p"

❯ time httpx/bin/pip install httpx --no-cache-dir
Collecting httpx
  Downloading httpx-0.27.2-py3-none-any.whl.metadata (7.1 kB)
Collecting anyio (from httpx)
  Downloading anyio-4.4.0-py3-none-any.whl.metadata (4.6 kB)
Collecting certifi (from httpx)
  Downloading certifi-2024.8.30-py3-none-any.whl.metadata (2.2 kB)
Collecting httpcore==1.* (from httpx)
  Downloading httpcore-1.0.5-py3-none-any.whl.metadata (20 kB)
Collecting idna (from httpx)
  Downloading idna-3.8-py3-none-any.whl.metadata (9.9 kB)
Collecting sniffio (from httpx)
  Downloading sniffio-1.3.1-py3-none-any.whl.metadata (3.9 kB)
Collecting h11<0.15,>=0.13 (from httpcore==1.*->httpx)
  Downloading h11-0.14.0-py3-none-any.whl.metadata (8.2 kB)
Downloading httpx-0.27.2-py3-none-any.whl (76 kB)
Downloading httpcore-1.0.5-py3-none-any.whl (77 kB)
Downloading anyio-4.4.0-py3-none-any.whl (86 kB)
Downloading idna-3.8-py3-none-any.whl (66 kB)
Downloading sniffio-1.3.1-py3-none-any.whl (10 kB)
Downloading certifi-2024.8.30-py3-none-any.whl (167 kB)
Downloading h11-0.14.0-py3-none-any.whl (58 kB)
Installing collected packages: sniffio, idna, h11, certifi, httpcore, anyio, httpx
Successfully installed anyio-4.4.0 certifi-2024.8.30 h11-0.14.0 httpcore-1.0.5 httpx-0.27.2 idna-3.8 sniffio-1.3.1
httpx/bin/pip install httpx --no-cache-dir  0.45s user 0.11s system 47% cpu 1.192 total

❯ du -sh httpx
 16Mhttpx
```


</details>

