### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 1.18.0
     hooks:
       - id: blacken-docs
-        args: [--target-version=py38]
+        args: [--target-version=py39]
         additional_dependencies: [black]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Or from requirements.txt:
 
 Note:
 
-- pyLast 5.3+ supports Python 3.8-3.13.
-- pyLast 5.2+ supports Python 3.8-3.12.
+- pyLast 5.4+ supports Python 3.9-3.13.
+- pyLast 5.3 supports Python 3.8-3.13.
+- pyLast 5.2 supports Python 3.8-3.12.
 - pyLast 5.1 supports Python 3.7-3.11.
 - pyLast 5.0 supports Python 3.7-3.10.
 - pyLast 4.3 - 4.5 supports Python 3.6-3.10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,11 @@ keywords = [
 license = { text = "Apache-2.0" }
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Amr Hassan <amr.hassan@gmail.com> and Contributors", email = "amr.hassan@gmail.com" } ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{py3, 313, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan