### PR TITLE
Attest build provenance using GitHub's actions/attest-build-provenance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   # Always build & lint package.
   build-package:
@@ -38,6 +41,7 @@ jobs:
     needs: build-package
 
     permissions:
+      attestations: write
       id-token: write
 
     steps:
@@ -46,6 +50,11 @@ jobs:
         with:
           name: Packages
           path: dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/*"
 
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -62,6 +71,7 @@ jobs:
     needs: build-package
 
     permissions:
+      attestations: write
       id-token: write
 
     steps:
@@ -70,6 +80,11 @@ jobs:
         with:
           name: Packages
           path: dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/*"
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -22,13 +25,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          cache: pip
+
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
 
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
-          python -m pip install -U wheel
-          python -m pip install -U tox
+          uv pip install --system -U tox-uv
 
       - name: Tox tests
         run: |


### PR DESCRIPTION
* https://github.blog/news-insights/product-news/introducing-artifact-attestations-now-in-public-beta/
* https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds

Also use uv for the tests workflow.