### PR TITLE
Replace pre-commit/action with faster tox-dev/action-pre-commit-uv

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: hynek/build-and-inspect-python-package@v2
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,8 +1,5 @@
 name: Sync labels
 
-permissions:
-  pull-requests: write
-
 on:
   push:
     branches:
@@ -13,9 +10,13 @@ on:
 
 jobs:
   sync:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@v1
         with:
           prune: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
@@ -20,5 +19,4 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
-      - uses: pre-commit/action@v3.0.1
+      - uses: tox-dev/action-pre-commit-uv@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
# pre-commit/action

No cache: 1m 19s

https://github.com/pylast/pylast/actions/runs/11597729187/job/32291921076

With cache: 14s

https://github.com/pylast/pylast/actions/runs/11597757451/job/32292016450

# tox-dev/action-pre-commit-uv

No cache: 49s

https://github.com/pylast/pylast/actions/runs/11597731048/job/32291927858

With cache: 14s

https://github.com/pylast/pylast/actions/runs/11597758972/job/32292022348

---

Also fix warnigs from [zizmor](https://github.com/woodruffw/zizmor).