### PR TITLE
Only create PyPI digital attestations (PEP 740)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,7 @@ on:
       - published
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: 1
@@ -42,7 +41,6 @@ jobs:
     needs: build-package
 
     permissions:
-      attestations: write
       id-token: write
 
     steps:
@@ -51,11 +49,6 @@ jobs:
         with:
           name: Packages
           path: dist
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
 
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -72,7 +65,6 @@ jobs:
     needs: build-package
 
     permissions:
-      attestations: write
       id-token: write
 
     steps:
@@ -81,11 +73,6 @@ jobs:
         with:
           name: Packages
           path: dist
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Generating PyPI's digital attestations should be enough (https://docs.pypi.org/attestations/), we don't _also_ need to use https://github.com/actions/attest-build-provenance.

And we've not made any releases yet with GH attestations (added in https://github.com/pylast/pylast/pull/462).