### PR TITLE
Double read timeout to fix 'The read operation timed out'

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -893,7 +893,7 @@ class _Request:
         username = "" if username is None else f"?username={username}"
 
         (host_name, host_subdir) = self.network.ws_server
-        timeout = httpx.Timeout(5, read=10)
+        timeout = httpx.Timeout(5, read=20)
 
         if self.network.is_proxy_enabled():
             client = httpx.Client(


### PR DESCRIPTION
Fixes https://github.com/pylast/pylast/issues/470 (hopefully...)

Follow on from https://github.com/pylast/pylast/pull/445, double the read timeout to 20s.

https://www.python-httpx.org/advanced/timeouts/
