### PR TITLE
Remove redundant _unicode function

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,7 @@
 exclude_also =
     # Don't complain if non-runnable code isn't run:
     if TYPE_CHECKING:
+
+[run]
+disable_warnings =
+    no-sysmon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,4 @@ lint.isort.required-imports = [ "from __future__ import annotations" ]
 max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
-filterwarnings = [
-  # Python <= 3.11
-  "ignore:sys.monitoring isn't available, using default core:coverage.exceptions.CoverageWarning",
-]
 testpaths = [ "tests" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ lint.ignore = [
   "E221",   # Multiple spaces before operator
   "E226",   # Missing whitespace around arithmetic operator
   "E241",   # Multiple spaces after ','
-  "PIE790", # flake8-pie: unnecessary-placeholder
+  "PIE790", # Unnecessary pass statement
   "UP038",  # Makes code slower and more verbose
 ]
 lint.flake8-import-conventions.aliases.datetime = "dt"
@@ -100,3 +100,7 @@ max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]
+
+[tool.mypy]
+pretty = true
+show_error_codes = true

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -833,7 +833,7 @@ class _Request:
         self.params = {}
 
         for key in params:
-            self.params[key] = _unicode(params[key])
+            self.params[key] = str(params[key])
 
         (self.api_key, self.api_secret, self.session_key) = network._get_ws_auth()
 
@@ -939,7 +939,7 @@ class _Request:
                 response.status_code,
                 f"Connection to the API failed with HTTP code {response.status_code}",
             )
-        response_text = _unicode(response.read())
+        response_text = str(response.read(), "utf-8")
 
         try:
             self._check_response_for_errors(response_text)
@@ -2762,18 +2762,10 @@ class TrackSearch(_Search):
 
 def md5(text: str) -> str:
     """Returns the md5 hash of a string."""
-
     h = hashlib.md5()
-    h.update(_unicode(text).encode("utf-8"))
+    h.update(text.encode("utf-8"))
 
     return h.hexdigest()
-
-
-def _unicode(text: bytes | str) -> str:
-    if isinstance(text, bytes):
-        return str(text, "utf-8")
-    else:
-        return str(text)
 
 
 def cleanup_nodes(doc):


### PR DESCRIPTION
This is a leftover from Python 2 support:

```python
def _unicode(text: bytes | str) -> str:
    if isinstance(text, bytes):
        return str(text, "utf-8")
    else:
        return str(text)
```

We call it in three places.

* The first can be replaced with `str()`.

* The second with `str(..., "utf-8"`).

* And the third is immediately encoding a string with "utf-8" so can be dropped.

---

Plus some minor config changes.
