### PR TITLE
Replace `collections.namedtuple` with `typing.NamedTuple` and remove unused

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ lint.select = [
   "PGH",    # pygrep-hooks
   "PIE",    # flake8-pie
   "PT",     # flake8-pytest-style
+  "PYI",    # flake8-pyi
   "RUF022", # unsorted-dunder-all
   "RUF100", # unused noqa (yesqa)
   "UP",     # pyupgrade

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1092,7 +1092,7 @@ class SessionKeyGenerator:
 
 class TopItem(typing.NamedTuple):
     item: Artist | Album | Track | Tag
-    weight: int | float
+    weight: float
 
 
 class SimilarItem(typing.NamedTuple):
@@ -1102,20 +1102,20 @@ class SimilarItem(typing.NamedTuple):
 
 class LibraryItem(typing.NamedTuple):
     item: Artist
-    playcount: int
-    tagcount: int
+    playcount: float
+    tagcount: float
 
 
 class PlayedTrack(typing.NamedTuple):
     track: Track
-    album: str
-    playback_date: str
+    album: str | None
+    playback_date: str | None
     timestamp: str | None
 
 
 class LovedTrack(typing.NamedTuple):
     track: Track
-    date: str
+    date: str | None
     timestamp: str
 
 

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -20,7 +20,6 @@
 # https://github.com/pylast/pylast
 from __future__ import annotations
 
-import collections
 import hashlib
 import html.entities
 import logging
@@ -30,6 +29,7 @@ import shelve
 import ssl
 import tempfile
 import time
+import typing
 import xml.dom
 import xml.parsers
 from urllib.parse import quote_plus
@@ -1090,19 +1090,33 @@ class SessionKeyGenerator:
         return _extract(doc, "key")
 
 
-TopItem = collections.namedtuple("TopItem", ["item", "weight"])
-SimilarItem = collections.namedtuple("SimilarItem", ["item", "match"])
-LibraryItem = collections.namedtuple("LibraryItem", ["item", "playcount", "tagcount"])
-PlayedTrack = collections.namedtuple(
-    "PlayedTrack", ["track", "album", "playback_date", "timestamp"]
-)
-LovedTrack = collections.namedtuple("LovedTrack", ["track", "date", "timestamp"])
-ImageSizes = collections.namedtuple(
-    "ImageSizes", ["original", "large", "largesquare", "medium", "small", "extralarge"]
-)
-Image = collections.namedtuple(
-    "Image", ["title", "url", "dateadded", "format", "owner", "sizes", "votes"]
-)
+class TopItem(typing.NamedTuple):
+    item: Artist | Album | Track | Tag
+    weight: int | float
+
+
+class SimilarItem(typing.NamedTuple):
+    item: Artist | Track
+    match: float
+
+
+class LibraryItem(typing.NamedTuple):
+    item: Artist
+    playcount: int
+    tagcount: int
+
+
+class PlayedTrack(typing.NamedTuple):
+    track: Track
+    album: str
+    playback_date: str
+    timestamp: str | None
+
+
+class LovedTrack(typing.NamedTuple):
+    track: Track
+    date: str
+    timestamp: str
 
 
 def _string_output(func):


### PR DESCRIPTION
Fixes https://github.com/pylast/pylast/issues/480

Changes proposed in this pull request:

 * Replace `collections.namedtuple` with `typing.NamedTuple` for `TopItem`, `SimilarItem`, `LibraryItem`, `PlayedTrack` and `LovedTrack`
 * Remove unused `ImageSizes` and `Image`, their use was removed in https://github.com/pylast/pylast/commit/d3dba1475ab1615aae421d1e418f9134554c561c in 1.0.0. We're now on 5.x so I won't plan deprecations or a major bump.
 * Add PYI to Ruff rules.
