### PR TITLE
Restore proxy support

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -156,6 +156,7 @@ class _Network:
         domain_names,
         urls,
         token=None,
+        proxy=None,
     ) -> None:
         """
         name: the name of the network
@@ -171,6 +172,7 @@ class _Network:
             name
         urls: a dict mapping types to URLs
         token: an authentication token to retrieve a session
+        proxy: A string URL for a proxy server that handles network requests.
 
         if username and password_hash were provided and not session_key,
         session_key will be generated automatically when needed.
@@ -193,9 +195,9 @@ class _Network:
         self.password_hash = password_hash
         self.domain_names = domain_names
         self.urls = urls
+        self.proxy: str | None = proxy
 
         self.cache_backend: _ShelfCacheBackend | None = None
-        self.proxy: str | dict | None = None
         self.last_call_time: float = 0.0
         self.limit_rate = False
 
@@ -407,10 +409,9 @@ class _Network:
 
         return seq
 
-    def enable_proxy(self, proxy: str | dict) -> None:
+    def enable_proxy(self, proxy: str) -> None:
         """Enable default web proxy.
-        Multiple proxies can be passed as a `dict`, see
-        https://www.python-httpx.org/advanced/#http-proxying
+        https://www.python-httpx.org/advanced/proxies
         """
         self.proxy = proxy
 
@@ -655,6 +656,7 @@ class LastFMNetwork(_Network):
     username: a username of a valid user
     password_hash: the output of pylast.md5(password) where password is the
         user's password
+    proxy: A string URL for a proxy server that handles network requests.
 
     if username and password_hash were provided and not session_key,
     session_key will be generated automatically when needed.
@@ -675,6 +677,7 @@ class LastFMNetwork(_Network):
         username: str = "",
         password_hash: str = "",
         token: str = "",
+        proxy: str = None,
     ) -> None:
         super().__init__(
             name="Last.fm",
@@ -686,6 +689,7 @@ class LastFMNetwork(_Network):
             username=username,
             password_hash=password_hash,
             token=token,
+            proxy=proxy,
             domain_names={
                 DOMAIN_ENGLISH: "www.last.fm",
                 DOMAIN_GERMAN: "www.last.fm/de",
@@ -732,6 +736,7 @@ class LibreFMNetwork(_Network):
     username: a username of a valid user
     password_hash: the output of pylast.md5(password) where password is the
         user's password
+    proxy: A string URL for a proxy server that handles network requests.
 
     if username and password_hash were provided and not session_key,
     session_key will be generated automatically when needed.
@@ -744,6 +749,7 @@ class LibreFMNetwork(_Network):
         session_key: str = "",
         username: str = "",
         password_hash: str = "",
+        proxy: str = None,
     ) -> None:
         super().__init__(
             name="Libre.fm",
@@ -754,6 +760,7 @@ class LibreFMNetwork(_Network):
             session_key=session_key,
             username=username,
             password_hash=password_hash,
+            proxy=proxy,
             domain_names={
                 DOMAIN_ENGLISH: "libre.fm",
                 DOMAIN_GERMAN: "libre.fm",
@@ -917,7 +924,7 @@ class _Request:
                 verify=SSL_CONTEXT,
                 base_url=f"https://{host_name}",
                 headers=HEADERS,
-                proxies=self.network.proxy,
+                proxy=self.network.proxy,
                 timeout=timeout,
             )
         else:


### PR DESCRIPTION
The deprecated `proxies` argument used for proxy support was removed in httpx 0.28.0.
This commit replaces the deprecated `proxies` argument with `proxy` to restore functionality.

The `proxy` argument has also been added to the `_Network` and it's subclasses, for easier set up.

Fixes #486

Changes proposed in this pull request:

 * `proxies` changed to `proxy`
 * class `_Network` and its subclasses now has the `proxy` argument
