### PR TITLE
Fix `AuthenticatedUser.get_name` returning empty string

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2656,7 +2656,15 @@ class AuthenticatedUser(User):
 
     def get_name(self, properly_capitalized: bool = False):
         """Returns the name of the authenticated user."""
-        return super().get_name(properly_capitalized=properly_capitalized)
+        if not self.name or properly_capitalized:
+            # user.getInfo returns the authenticated user when called with a
+            # session key and no `user` param, so we can resolve our own name
+            # even when the network was constructed without a username.
+            doc = _Request(self.network, self.ws_prefix + ".getInfo").execute(
+                cacheable=True
+            )
+            self.name = _extract(doc, "name")
+        return self.name
 
 
 class _Search(_BaseObject):

--- a/tests/test_authenticated_user.py
+++ b/tests/test_authenticated_user.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+from xml.dom import minidom
+
+import pylast
+
+
+def _fake_user_getinfo_doc(name: str) -> minidom.Document:
+    xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<lfm status="ok"><user><name>{name}</name></user></lfm>'
+    )
+    return minidom.parseString(xml)
+
+
+def test_authenticated_user_get_name_resolves_via_api_when_username_missing() -> None:
+    # Regression test for #300: with a session-key-only network (the typical
+    # web-auth flow), AuthenticatedUser used to return an empty name because
+    # network.username was never populated.
+    network = pylast.LastFMNetwork(
+        api_key="key", api_secret="secret", session_key="session"
+    )
+
+    user = network.get_authenticated_user()
+    assert user.name == ""
+
+    with patch.object(
+        pylast._Request, "execute", return_value=_fake_user_getinfo_doc("Alice")
+    ) as execute:
+        assert user.get_name() == "Alice"
+        assert execute.call_count == 1
+
+    assert user.name == "Alice"
+    assert user.get_name() == "Alice"
+
+
+def test_authenticated_user_get_name_uses_existing_name_when_set() -> None:
+    network = pylast.LastFMNetwork(
+        api_key="key",
+        api_secret="secret",
+        session_key="session",
+        username="Bob",
+    )
+
+    user = network.get_authenticated_user()
+
+    with patch.object(pylast._Request, "execute") as execute:
+        assert user.get_name() == "Bob"
+        execute.assert_not_called()


### PR DESCRIPTION
## Summary

When `LastFMNetwork` is constructed with only a `session_key` (the typical web-auth flow), `network.username` is never populated. `AuthenticatedUser` then ends up with `self.name = ""` and `get_name()` returns an empty string. This also breaks any user method that needs the username, since `_get_params` returns `{"user": ""}`.

The fix makes `AuthenticatedUser.get_name` resolve the name lazily by calling `user.getInfo`. When the request is authenticated with a session key and no `user` param is supplied, Last.fm returns the authenticated user's info, so we can get our own name without the caller having to provide it.

Fixes #300.

## Test plan

- [x] New unit tests in `tests/test_authenticated_user.py` cover the session-key-only flow and the username-already-set flow
- [x] `pytest --block-network` passes (140 passed, 9 skipped, 1 xfailed)
- [x] `ruff` and `black` clean