### PR TITLE
Add Album.get_album_artist_from_tracks and find_compilation_variant

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1687,6 +1687,49 @@ class Album(_Opus):
             self._request(self.ws_prefix + ".getInfo", cacheable=True), self.network
         )
 
+    def find_compilation_variant(self) -> Album | None:
+        """Returns the 'Various Artists' variant of this album if one exists.
+
+        Last.fm sometimes has the same compilation indexed under multiple
+        artist names. Returns self if already constructed with 'Various
+        Artists', a new Album for the canonical entry if it has real track
+        data, else None. Stub entries with no tracks are rejected because
+        Last.fm has many of them from stray mis-scrobbles.
+        """
+        artist = self.get_artist()
+        if TYPE_CHECKING:
+            assert artist is not None
+        if artist.get_name() == "Various Artists":
+            return self
+        variant = Album("Various Artists", self.title, self.network)
+        try:
+            doc = variant._request("album.getInfo", cacheable=True)
+        except WSError:
+            return None
+        if not doc.getElementsByTagName("track"):
+            return None
+        return variant
+
+    def get_album_artist_from_tracks(self) -> str | None:
+        """Returns the album artist inferred from the track listing.
+
+        Returns the single artist if all tracks share one, "Various Artists"
+        if tracks have multiple, or None if no track data is available.
+        """
+        tracks = self.get_tracks()
+        artist_names: set[str] = set()
+        for track in tracks:
+            if track.artist is None:
+                continue
+            name = track.artist.get_name()
+            if name:
+                artist_names.add(name)
+        if not artist_names:
+            return None
+        if len(artist_names) == 1:
+            return next(iter(artist_names))
+        return "Various Artists"
+
     def get_url(self, domain_name: int = DOMAIN_ENGLISH):
         """Returns the URL of the album or track page on the network.
         # Parameters:

--- a/tests/test_album_artist.py
+++ b/tests/test_album_artist.py
@@ -84,3 +84,29 @@ def test_find_compilation_variant_returns_none_for_stub_variant() -> None:
     doc = _album_info_doc([])
     with patch.object(pylast._Request, "execute", return_value=doc):
         assert album.find_compilation_variant() is None
+
+
+def test_find_compilation_variant_returns_self_when_already_various_artists() -> None:
+    album = _make_album(artist="Various Artists", title="UKF10")
+    with patch.object(pylast._Request, "execute") as execute:
+        variant = album.find_compilation_variant()
+    assert variant is album
+    execute.assert_not_called()
+
+
+def test_find_compilation_variant_returns_none_when_variant_lookup_fails() -> None:
+    album = _make_album()
+    error = pylast.WSError(album.network, "6", "Album not found")
+    with patch.object(pylast._Request, "execute", side_effect=error):
+        assert album.find_compilation_variant() is None
+
+
+def test_get_album_artist_from_tracks_skips_tracks_with_no_artist() -> None:
+    album = _make_album()
+    good_track = pylast.Track("Houkago Tea Time", "Cagayake! GIRLS", album.network)
+    orphan_track = pylast.Track("Houkago Tea Time", "Fuwa Fuwa Time", album.network)
+    orphan_track.artist = None
+    with patch.object(
+        pylast.Album, "get_tracks", return_value=[good_track, orphan_track]
+    ):
+        assert album.get_album_artist_from_tracks() == "Houkago Tea Time"

--- a/tests/test_album_artist.py
+++ b/tests/test_album_artist.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+from xml.dom import minidom
+from xml.sax.saxutils import escape
+
+import pylast
+
+
+def _album_info_doc(tracks: list[tuple[str, str]]) -> minidom.Document:
+    track_xml = "".join(
+        f"<track><name>{escape(title)}</name>"
+        f"<artist><name>{escape(artist)}</name></artist></track>"
+        for title, artist in tracks
+    )
+    xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<lfm status="ok"><album>'
+        "<name>Some Album</name>"
+        f"<tracks>{track_xml}</tracks>"
+        "</album></lfm>"
+    )
+    return minidom.parseString(xml)
+
+
+def _make_album(
+    artist: str = "Yui Hirasawa", title: str = "Ho-kago Tea Time"
+) -> pylast.Album:
+    network = pylast.LastFMNetwork(api_key="key", api_secret="secret")
+    return pylast.Album(artist, title, network)
+
+
+def test_returns_single_artist_when_all_tracks_agree() -> None:
+    album = _make_album()
+    doc = _album_info_doc(
+        [
+            ("Cagayake! GIRLS", "Houkago Tea Time"),
+            ("Fuwa Fuwa Time", "Houkago Tea Time"),
+            ("Don't say 'lazy'", "Houkago Tea Time"),
+        ]
+    )
+    with patch.object(pylast._Request, "execute", return_value=doc):
+        assert album.get_album_artist_from_tracks() == "Houkago Tea Time"
+
+
+def test_returns_various_artists_for_multi_artist_compilation() -> None:
+    album = _make_album(title="K-ON! Character Song Collection")
+    doc = _album_info_doc(
+        [
+            ("Pure Pure Heart", "Aki Toyosaki"),
+            ("Heart Goes Boom!!", "Yoko Hikasa"),
+            ("Diary wa Fortissimo", "Satomi Sato"),
+            ("Honey Sweet Tea Time", "Minako Kotobuki"),
+            ("Singing!", "Ayana Taketatsu"),
+        ]
+    )
+    with patch.object(pylast._Request, "execute", return_value=doc):
+        assert album.get_album_artist_from_tracks() == "Various Artists"
+
+
+def test_returns_none_for_stub_entry_with_no_tracks() -> None:
+    album = _make_album()
+    doc = _album_info_doc([])
+    with patch.object(pylast._Request, "execute", return_value=doc):
+        assert album.get_album_artist_from_tracks() is None
+
+
+def test_find_compilation_variant_returns_album_when_variant_has_tracks() -> None:
+    album = _make_album(title="K-ON! Character Song Collection")
+    doc = _album_info_doc(
+        [
+            ("Pure Pure Heart", "Aki Toyosaki"),
+            ("Heart Goes Boom!!", "Yoko Hikasa"),
+        ]
+    )
+    with patch.object(pylast._Request, "execute", return_value=doc):
+        variant = album.find_compilation_variant()
+    assert variant is not None
+    assert variant.get_artist().get_name() == "Various Artists"
+
+
+def test_find_compilation_variant_returns_none_for_stub_variant() -> None:
+    album = _make_album()
+    doc = _album_info_doc([])
+    with patch.object(pylast._Request, "execute", return_value=doc):
+        assert album.find_compilation_variant() is None


### PR DESCRIPTION
## Summary

Last.fm indexes albums by `(artist, album)`, so the same compilation can
exist under multiple artist names. `Album.artist` just echoes the constructor
arg, so users querying with a track artist get that back even when the album
is really a compilation.

Two new methods on `Album`:

- `get_album_artist_from_tracks()`: returns the single artist if all tracks
  on `album.getInfo` agree, "Various Artists" if they don't, None for stubs.
- `find_compilation_variant()`: probes for a "Various Artists" copy of the
  same title, but only returns it if it has real track data (Last.fm has
  plenty of empty stubs from stray scrobbles).

For #331:

```python
release = network.get_album("Fourward", "UKF10 - Ten Years Of UKF")
variant = release.find_compilation_variant()
print((variant or release).get_album_artist_from_tracks())  # "Various Artists"
```

Non-breaking. Fixes #331.

## Test plan

- [x] 5 unit tests in `tests/test_album_artist.py`
- [x] `pytest --block-network` passes
- [x] ruff, black, mypy clean