### PR TITLE
Return empty result instead of `IndexError` on empty search

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2692,7 +2692,10 @@ class _Search(_BaseObject):
         params["page"] = str(page_index)
         doc = self._request(self._ws_prefix + ".search", True, params)
 
-        return doc.getElementsByTagName(self._ws_prefix + "matches")[0]
+        matches = doc.getElementsByTagName(self._ws_prefix + "matches")
+        if not matches:
+            return doc.createElement(self._ws_prefix + "matches")
+        return matches[0]
 
     def _retrieve_next_page(self) -> minidom.Element:
         self._last_page_index += 1

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -2692,10 +2692,10 @@ class _Search(_BaseObject):
         params["page"] = str(page_index)
         doc = self._request(self._ws_prefix + ".search", True, params)
 
-        matches = doc.getElementsByTagName(self._ws_prefix + "matches")
-        if not matches:
-            return doc.createElement(self._ws_prefix + "matches")
-        return matches[0]
+        if matches := doc.getElementsByTagName(self._ws_prefix + "matches"):
+            return matches[0]
+
+        return doc.createElement(self._ws_prefix + "matches")
 
     def _retrieve_next_page(self) -> minidom.Element:
         self._last_page_index += 1


### PR DESCRIPTION
## Summary

`_Search._retrieve_page` did `doc.getElementsByTagName(...)[0]`, assuming
the response always has a `<matches>` element. Last.fm returns `status="ok"`
without it for some inputs (e.g. empty search string), so this crashed with
`IndexError` which is not part of pylast's exception hierarchy.

Returns an empty placeholder element when missing, so callers see `[]`
instead of an internal exception.

## Repro

```python
network.search_for_artist("").get_next_page()
# Before: IndexError: list index out of range
# After:  []
```

## Test plan

- [x] Verified live against the real API: empty search returns `[]`,
      normal searches still return results
- [x] `pytest --block-network` passes (138)
- [x] ruff, black, mypy clean