### PR TITLE
Fix `Country` and `Tag` equality raising `AttributeError`

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -1924,7 +1924,10 @@ class Country(_BaseObject):
         return self.get_name()
 
     def __eq__(self, other):
-        return self.get_name().lower() == other.get_name().lower()
+        if type(self) is type(other):
+            return self.get_name().lower() == other.get_name().lower()
+        else:
+            return False
 
     def __ne__(self, other) -> bool:
         return not self == other
@@ -2048,7 +2051,10 @@ class Tag(_Chartable):
         return self.get_name()
 
     def __eq__(self, other):
-        return self.get_name().lower() == other.get_name().lower()
+        if type(self) is type(other):
+            return self.get_name().lower() == other.get_name().lower()
+        else:
+            return False
 
     def __ne__(self, other) -> bool:
         return not self == other

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import pylast
 
 
@@ -7,49 +9,31 @@ def _network() -> pylast.LastFMNetwork:
     return pylast.LastFMNetwork(api_key="key", api_secret="secret")
 
 
-def test_country_equality_with_none_returns_false() -> None:
-    country = pylast.Country("Italy", _network())
-    assert (country == None) is False  # noqa: E711
-    assert (country != None) is True  # noqa: E711
+THINGS = [
+    pytest.param(pylast.Country, "Italy", "Finland", id="country"),
+    pytest.param(pylast.Tag, "rock", "jazz", id="tag"),
+]
 
 
-def test_country_equality_with_string_returns_false() -> None:
-    country = pylast.Country("Italy", _network())
-    assert (country == "Italy") is False
-    assert (country != "Italy") is True
+@pytest.mark.parametrize("cls, name, other_name", THINGS)
+@pytest.mark.parametrize("other", [None, "Italy"])
+def test_equality_with_non_matching_type_returns_false(
+    cls, name, other_name, other
+) -> None:
+    obj = cls(name, _network())
+    assert (obj == other) is False
+    assert (obj != other) is True
 
 
-def test_country_in_list_with_strings_does_not_raise() -> None:
+@pytest.mark.parametrize("cls, name, other_name", THINGS)
+def test_in_list_does_not_raise_on_string_comparison(cls, name, other_name) -> None:
     network = _network()
-    countries = [pylast.Country("Italy", network), pylast.Country("Finland", network)]
-    assert "Italy" not in countries
+    things = [cls(name, network), cls(other_name, network)]
+    assert "blues" not in things
 
 
-def test_country_equality_is_case_insensitive() -> None:
+@pytest.mark.parametrize("cls, name, other_name", THINGS)
+def test_equality_is_case_insensitive(cls, name, other_name) -> None:
     network = _network()
-    assert pylast.Country("Italy", network) == pylast.Country("italy", network)
-    assert pylast.Country("Italy", network) != pylast.Country("Finland", network)
-
-
-def test_tag_equality_with_none_returns_false() -> None:
-    tag = pylast.Tag("rock", _network())
-    assert (tag == None) is False  # noqa: E711
-    assert (tag != None) is True  # noqa: E711
-
-
-def test_tag_equality_with_string_returns_false() -> None:
-    tag = pylast.Tag("rock", _network())
-    assert (tag == "rock") is False
-    assert (tag != "rock") is True
-
-
-def test_tag_in_list_with_strings_does_not_raise() -> None:
-    network = _network()
-    tags = [pylast.Tag("rock", network), pylast.Tag("jazz", network)]
-    assert "blues" not in tags
-
-
-def test_tag_equality_is_case_insensitive() -> None:
-    network = _network()
-    assert pylast.Tag("Rock", network) == pylast.Tag("rock", network)
-    assert pylast.Tag("rock", network) != pylast.Tag("jazz", network)
+    assert cls(name, network) == cls(name.lower(), network)
+    assert cls(name, network) != cls(other_name, network)

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pylast
+
+
+def _network() -> pylast.LastFMNetwork:
+    return pylast.LastFMNetwork(api_key="key", api_secret="secret")
+
+
+def test_country_equality_with_none_returns_false() -> None:
+    country = pylast.Country("Italy", _network())
+    assert (country == None) is False  # noqa: E711
+    assert (country != None) is True  # noqa: E711
+
+
+def test_country_equality_with_string_returns_false() -> None:
+    country = pylast.Country("Italy", _network())
+    assert (country == "Italy") is False
+    assert (country != "Italy") is True
+
+
+def test_country_in_list_with_strings_does_not_raise() -> None:
+    network = _network()
+    countries = [pylast.Country("Italy", network), pylast.Country("Finland", network)]
+    assert "Italy" not in countries
+
+
+def test_country_equality_is_case_insensitive() -> None:
+    network = _network()
+    assert pylast.Country("Italy", network) == pylast.Country("italy", network)
+    assert pylast.Country("Italy", network) != pylast.Country("Finland", network)
+
+
+def test_tag_equality_with_none_returns_false() -> None:
+    tag = pylast.Tag("rock", _network())
+    assert (tag == None) is False  # noqa: E711
+    assert (tag != None) is True  # noqa: E711
+
+
+def test_tag_equality_with_string_returns_false() -> None:
+    tag = pylast.Tag("rock", _network())
+    assert (tag == "rock") is False
+    assert (tag != "rock") is True
+
+
+def test_tag_in_list_with_strings_does_not_raise() -> None:
+    network = _network()
+    tags = [pylast.Tag("rock", network), pylast.Tag("jazz", network)]
+    assert "blues" not in tags
+
+
+def test_tag_equality_is_case_insensitive() -> None:
+    network = _network()
+    assert pylast.Tag("Rock", network) == pylast.Tag("rock", network)
+    assert pylast.Tag("rock", network) != pylast.Tag("jazz", network)


### PR DESCRIPTION
## Summary

`Country.__eq__` and `Tag.__eq__` call `other.get_name().lower()` without checking that `other` is the same type, so comparing against anything else raises `AttributeError`:

```python
>>> pylast.Country("US", network) == None
AttributeError: 'NoneType' object has no attribute 'get_name'
>>> "blues" in [pylast.Tag("rock", network)]
AttributeError: 'str' object has no attribute 'get_name'
```

`Artist`, `User`, `Album`, and `Track` all guard against this. `Country` and `Tag` were the two missing pieces. The fix matches the pattern already used in `Artist.__eq__`.

## Test plan

- [x] 8 new unit tests in `tests/test_equality.py`
- [x] `pytest --block-network` passes (148 passed, 9 skipped, 1 xfailed)
- [x] ruff and black clean