### PR TITLE
Fix cache miss on requests with username param

### DIFF
--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -942,7 +942,8 @@ class _Request:
         if self.network.limit_rate:
             self.network._delay_call()
 
-        username = self.params.pop("username", None)
+        params = dict(self.params)
+        username = params.pop("username", None)
         username = "" if username is None else f"?username={username}"
 
         host_name, host_subdir = self.network.ws_server
@@ -956,7 +957,7 @@ class _Request:
             timeout=timeout,
         ) as client:
             try:
-                response = client.post(f"{host_subdir}{username}", data=self.params)
+                response = client.post(f"{host_subdir}{username}", data=params)
             except Exception as e:
                 raise NetworkError(self.network, e) from e
 

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -942,7 +942,7 @@ class _Request:
         if self.network.limit_rate:
             self.network._delay_call()
 
-        params = dict(self.params)
+        params = self.params.copy()
         username = params.pop("username", None)
         username = "" if username is None else f"?username={username}"
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 import pylast
@@ -11,3 +13,52 @@ import pylast
 )
 def test_param_conversion(given: bool | int | str, expected: str) -> None:
     assert pylast._Request._convert_param(given) == expected
+
+
+def _fake_post_factory(call_counter: list[int]) -> object:
+    body = (
+        b'<?xml version="1.0"?>'
+        b'<lfm status="ok"><album><userplaycount>1</userplaycount></album></lfm>'
+    )
+
+    def fake_post(*args, **kwargs):
+        call_counter.append(1)
+
+        class _Response:
+            status_code = 200
+
+            def read(self) -> bytes:
+                return body
+
+        return _Response()
+
+    return fake_post
+
+
+def test_download_response_does_not_mutate_params() -> None:
+    network = pylast.LastFMNetwork(api_key="k", api_secret="s")
+    request = pylast._Request(
+        network, "album.getInfo", {"artist": "A", "album": "B", "username": "alice"}
+    )
+    original = dict(request.params)
+
+    calls: list[int] = []
+    with patch("httpx.Client.post", side_effect=_fake_post_factory(calls)):
+        request._download_response()
+
+    assert request.params == original
+    assert "username" in request.params
+
+
+def test_cacheable_request_with_username_param_hits_cache_on_second_call() -> None:
+    network = pylast.LastFMNetwork(api_key="k", api_secret="s")
+    network.enable_caching()
+    album = pylast.Album("Beatles", "Abbey Road", network, username="alice")
+
+    calls: list[int] = []
+    with patch("httpx.Client.post", side_effect=_fake_post_factory(calls)):
+        album.get_userplaycount()
+        album.get_userplaycount()
+        album.get_userplaycount()
+
+    assert len(calls) == 1

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -15,24 +15,14 @@ def test_param_conversion(given: bool | int | str, expected: str) -> None:
     assert pylast._Request._convert_param(given) == expected
 
 
-def _fake_post_factory(call_counter: list[int]) -> object:
-    body = (
-        b'<?xml version="1.0"?>'
-        b'<lfm status="ok"><album><userplaycount>1</userplaycount></album></lfm>'
-    )
+FAKE_BODY = (
+    b'<?xml version="1.0"?>'
+    b'<lfm status="ok"><album><userplaycount>1</userplaycount></album></lfm>'
+)
 
-    def fake_post(*args, **kwargs):
-        call_counter.append(1)
 
-        class _Response:
-            status_code = 200
-
-            def read(self) -> bytes:
-                return body
-
-        return _Response()
-
-    return fake_post
+def _fake_response() -> Mock:
+    return Mock(status_code=200, read=Mock(return_value=FAKE_BODY))
 
 
 def test_download_response_does_not_mutate_params() -> None:
@@ -42,8 +32,7 @@ def test_download_response_does_not_mutate_params() -> None:
     )
     original = dict(request.params)
 
-    calls: list[int] = []
-    with patch("httpx.Client.post", side_effect=_fake_post_factory(calls)):
+    with patch("httpx.Client.post", return_value=_fake_response()):
         request._download_response()
 
     assert request.params == original
@@ -55,10 +44,9 @@ def test_cacheable_request_with_username_param_hits_cache_on_second_call() -> No
     network.enable_caching()
     album = pylast.Album("Beatles", "Abbey Road", network, username="alice")
 
-    calls: list[int] = []
-    with patch("httpx.Client.post", side_effect=_fake_post_factory(calls)):
+    with patch("httpx.Client.post", return_value=_fake_response()) as post:
         album.get_userplaycount()
         album.get_userplaycount()
         album.get_userplaycount()
 
-    assert len(calls) == 1
+    assert post.call_count == 1


### PR DESCRIPTION
## Summary

`_Request._download_response` was popping `username` from `self.params` to put it in the URL query string. Cacheable requests compute their cache key from `self.params`, so:

1. `_get_cached_response` checks the cache with a key that includes `username`
2. `_download_response` pops `username`
3. The response is then stored under a key without `username`
4. Next call: step 1 looks for the with-username key again, miss

The cache fills with entries that are never read. Anything passing `username` as a param is affected: `Album.get_userplaycount`, `Artist.get_userplaycount`, `Track.get_userplaycount`, `Track.get_userloved`.

Fix uses a local copy of the params dict for the outgoing request, leaving `self.params` untouched.

## Test plan

- [x] new test confirming `_download_response` no longer mutates `self.params`
- [x] new test confirming `Album.get_userplaycount` with caching enabled now hits the cache (3 calls produce 1 network request)
- [x] `pytest --block-network` passes (142 passed, 9 skipped, 1 xfailed)
- [x] ruff and black clean