### PR TITLE
Replace HTTPX with HTTPX2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "httpx>=0.26",
+  "httpx2",
 ]
 optional-dependencies.tests = [
   "flaky",

--- a/src/pylast/__init__.py
+++ b/src/pylast/__init__.py
@@ -34,7 +34,7 @@ import xml.parsers
 from urllib.parse import quote_plus
 from xml.dom import Node, minidom
 
-import httpx
+import httpx2 as httpx
 
 from ._version import __version__
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -32,7 +32,7 @@ def test_download_response_does_not_mutate_params() -> None:
     )
     original = dict(request.params)
 
-    with patch("httpx.Client.post", return_value=_fake_response()):
+    with patch("httpx2.Client.post", return_value=_fake_response()):
         request._download_response()
 
     assert request.params == original
@@ -44,7 +44,7 @@ def test_cacheable_request_with_username_param_hits_cache_on_second_call() -> No
     network.enable_caching()
     album = pylast.Album("Beatles", "Abbey Road", network, username="alice")
 
-    with patch("httpx.Client.post", return_value=_fake_response()) as post:
+    with patch("httpx2.Client.post", return_value=_fake_response()) as post:
         album.get_userplaycount()
         album.get_userplaycount()
         album.get_userplaycount()


### PR DESCRIPTION
https://github.com/pydantic/httpx2 is a continuation of https://github.com/encode/httpx.